### PR TITLE
fix: handle empty content states gracefully

### DIFF
--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -15,20 +15,26 @@ const allPosts = await getAllBlogPosts();
 const recentPosts = allPosts.slice(0, limit);
 ---
 
-<section class:list={cn("flex flex-col gap-y-4", className)}>
-  <div class="flex items-center justify-between">
-    <h2 class="text-lg font-semibold text-foreground">Latest Posts</h2>
-    <Link
-      href="/blog"
-      class="group inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-      prefetch="viewport"
-    >
-      View all
-      <ArrowRight size={14} class="transition-transform group-hover:translate-x-0.5" />
-    </Link>
-  </div>
+{
+  recentPosts.length > 0 && (
+    <section class:list={cn("flex flex-col gap-y-4", className)}>
+      <div class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-foreground">Latest Posts</h2>
+        <Link
+          href="/blog"
+          class="group inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          prefetch="viewport"
+        >
+          View all
+          <ArrowRight size={14} class="transition-transform group-hover:translate-x-0.5" />
+        </Link>
+      </div>
 
-  <div class="flex flex-col gap-4">
-    {recentPosts.map((post) => <BlogCard post={post} />)}
-  </div>
-</section>
+      <div class="flex flex-col gap-4">
+        {recentPosts.map((post) => (
+          <BlogCard post={post} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -14,6 +14,22 @@ export async function getStaticPaths() {
   const totalPosts = allPosts.length;
   const totalPages = Math.ceil(totalPosts / SITE.postsPerPage);
 
+  // Always generate at least the first page, even when empty
+  if (totalPages === 0) {
+    return [
+      {
+        params: { page: undefined },
+        props: {
+          items: [],
+          currentPage: 1,
+          totalPages: 0,
+          hasNext: false,
+          hasPrev: false,
+        },
+      },
+    ];
+  }
+
   // Generate paths for all pages
   return Array.from({ length: totalPages }, (_, i) => {
     const page = i + 1;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,10 @@ import Hero from "@/components/Hero.astro";
 import RecentPosts from "@/components/RecentPosts.astro";
 import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
+import { getAllBlogPosts } from "@/lib/blog";
+
+const allPosts = await getAllBlogPosts();
+const hasPosts = allPosts.length > 0;
 ---
 
 <Layout
@@ -14,8 +18,12 @@ import Layout from "@/layouts/Layout.astro";
   <div class="w-full mx-auto flex grow flex-col px-4 max-w-3xl page-enter">
     <Hero />
 
-    <section class="py-12 border-t border-border/50 page-enter page-enter-delay-2">
-      <RecentPosts />
-    </section>
+    {
+      hasPosts && (
+        <section class="py-12 border-t border-border/50 page-enter page-enter-delay-2">
+          <RecentPosts />
+        </section>
+      )
+    }
   </div>
 </Layout>

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -14,6 +14,22 @@ export async function getStaticPaths() {
   const totalProjects = sortedProjects.length;
   const totalPages = Math.ceil(totalProjects / SITE.projectsPerPage);
 
+  // Always generate at least the first page, even when empty
+  if (totalPages === 0) {
+    return [
+      {
+        params: { page: undefined },
+        props: {
+          items: [],
+          currentPage: 1,
+          totalPages: 0,
+          hasNext: false,
+          hasPrev: false,
+        },
+      },
+    ];
+  }
+
   // Generate paths for all pages
   return Array.from({ length: totalPages }, (_, i) => {
     const page = i + 1;


### PR DESCRIPTION
## Summary

Fixes handling of empty content states to show appropriate empty state messages instead of 404 errors, and hides the Latest Posts section when no posts exist.

## Changes

### Blog Page (`src/pages/blog/[...page].astro`)
- Modified `getStaticPaths` to always generate at least the first page, even when there are no posts
- This ensures the `/blog` route exists and shows the "No blog posts to display yet" message instead of a 404

### Projects Page (`src/pages/projects/[...page].astro`)
- Modified `getStaticPaths` to always generate at least the first page, even when there are no projects
- This ensures the `/projects` route exists and shows the "No projects to display yet" message instead of a 404

### Recent Posts Component (`src/components/RecentPosts.astro`)
- Wrapped entire component in conditional to render nothing when there are no posts

### Home Page (`src/pages/index.astro`)
- Added check for posts existence
- Conditionally renders the Latest Posts section only when posts exist
- This prevents showing an empty section with just a border

## Verification

- [x] Site builds successfully with empty content collections
- [x] ESLint passes
- [x] Prettier formatting passes
- [x] `/blog` page shows empty state instead of 404
- [x] `/projects` page shows empty state instead of 404
- [x] Home page hides Latest Posts section when no posts exist