### PR TITLE
refactor: remove unused exports and options from lib modules

### DIFF
--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -2,21 +2,10 @@ import { type CollectionEntry, getCollection } from "astro:content";
 
 type Blog = CollectionEntry<"blog">;
 
-export async function getAllBlogPosts(options?: {
-  limit?: number;
-  includeDrafts?: boolean;
-}): Promise<Blog[]> {
-  let posts = await getCollection("blog");
+export async function getAllBlogPosts(): Promise<Blog[]> {
+  const posts = await getCollection("blog");
 
-  if (!options?.includeDrafts) {
-    posts = posts.filter((post) => !post.data.draft);
-  }
-
-  posts = posts.sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf());
-
-  if (options?.limit) {
-    posts = posts.slice(0, options.limit);
-  }
-
-  return posts;
+  return posts
+    .filter((post) => !post.data.draft)
+    .sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf());
 }

--- a/src/lib/content-tags.ts
+++ b/src/lib/content-tags.ts
@@ -1,7 +1,7 @@
 import { getCollection } from "astro:content";
 import { slugifyTag } from "@/lib/tags";
 
-export type ContentTag = {
+type ContentTag = {
   slug: string;
   label: string;
 };

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -2,36 +2,12 @@ import { type CollectionEntry, getCollection } from "astro:content";
 
 type Project = CollectionEntry<"projects">;
 
-export async function getAllProjects(options?: {
-  tags?: string[];
-  limit?: number;
-}): Promise<Project[]> {
-  let projects = await getCollection("projects");
+export async function getAllProjects(): Promise<Project[]> {
+  const projects = await getCollection("projects");
 
-  if (options?.tags && options.tags.length > 0) {
-    projects = projects.filter((project) =>
-      options.tags!.some((tag) => project.data.tags.includes(tag))
-    );
-  }
-
-  projects = projects.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
-
-  if (options?.limit) {
-    projects = projects.slice(0, options.limit);
-  }
-
-  return projects;
+  return projects.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 }
 
-export function sortProjects(projects: Project[], sortBy: "date" | "title" = "date"): Project[] {
-  const sorted = [...projects];
-
-  switch (sortBy) {
-    case "date":
-      return sorted.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
-    case "title":
-      return sorted.sort((a, b) => a.data.title.localeCompare(b.data.title));
-    default:
-      return sorted;
-  }
+export function sortProjects(projects: Project[]): Project[] {
+  return [...projects].sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 }

--- a/src/lib/scroll-reveal.ts
+++ b/src/lib/scroll-reveal.ts
@@ -1,6 +1,6 @@
 // Scroll-reveal controller — pure logic, no DOM side-effects
 
-export interface ScrollRevealOptions {
+interface ScrollRevealOptions {
   /** CSS selector for elements to observe */
   selector: string;
   /** Class added when element enters viewport */

--- a/src/lib/toc.ts
+++ b/src/lib/toc.ts
@@ -25,7 +25,7 @@ type MobileTocConfig = HeadingConfig & {
   enableSmoothScroll?: boolean;
 };
 
-export type TocController = {
+type TocController = {
   init: () => void;
   cleanup: () => void;
 };

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -14,7 +14,7 @@ import type { CollectionEntry } from "astro:content";
 
 export async function getStaticPaths() {
   const allProjects = await getAllProjects();
-  const sortedProjects = sortProjects(allProjects, "date");
+  const sortedProjects = sortProjects(allProjects);
   return generatePaginatedPaths(sortedProjects, SITE.projectsPerPage);
 }
 

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -26,8 +26,7 @@ export async function getStaticPaths() {
       post.data.tags.some((tag) => slugifyTag(tag) === slug)
     );
     const filteredProjects = sortProjects(
-      allProjects.filter((project) => project.data.tags.some((tag) => slugifyTag(tag) === slug)),
-      "date"
+      allProjects.filter((project) => project.data.tags.some((tag) => slugifyTag(tag) === slug))
     );
 
     return {


### PR DESCRIPTION
## Summary
Clean up unused API surface across lib modules. Removes optional parameters that were never passed at any call site, unexports types that were never imported externally, and simplifies `sortProjects` to always sort by date — the only sort direction actually used.

## Changes
- **src/lib/blog.ts**: Remove unused `limit` and `includeDrafts` options from `getAllBlogPosts`
- **src/lib/projects.ts**: Remove unused `tags` and `limit` options from `getAllProjects`; simplify `sortProjects` to always sort by date
- **src/lib/content-tags.ts**: Unexport `ContentTag` type (no external consumers)
- **src/lib/scroll-reveal.ts**: Unexport `ScrollRevealOptions` interface (no external consumers)
- **src/lib/toc.ts**: Unexport `TocController` type (no external consumers)
- **src/pages/**: Update call sites to match simplified `sortProjects` signature

## Testing
- [x] `bun run verify` passed (type-check, lint, format, test, build)