### PR TITLE
refactor: remove redundant TOC heading filter in TOCList component

### DIFF
--- a/src/components/TOCList.astro
+++ b/src/components/TOCList.astro
@@ -1,6 +1,5 @@
 ---
 import type { MarkdownHeading } from "astro";
-import { filterTocHeadings } from "@/lib/toc";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -17,7 +16,6 @@ interface Props {
 }
 
 const { headings, listId, listClass, linkClass, dataAttr, itemClass } = Astro.props;
-const filteredHeadings = filterTocHeadings(headings);
 
 function getIndent(depth: number): string {
   return depth === 3 ? "ml-4" : "";
@@ -25,9 +23,9 @@ function getIndent(depth: number): string {
 ---
 
 {
-  filteredHeadings.length > 0 && (
+  headings.length > 0 && (
     <ul id={listId} class:list={cn("flex list-none flex-col gap-y-2", listClass)}>
-      {filteredHeadings.map((heading) => (
+      {headings.map((heading) => (
         <li
           class:list={cn("text-sm", getIndent(heading.depth), itemClass)}
           style="color: var(--color-muted-foreground);"


### PR DESCRIPTION
## Summary
`filterTocHeadings` was called twice on the same heading data — once at the page level (`[...slug].astro`) and again inside `TOCList`. Since all callers already pre-filter headings to h2–h3, the second pass was unnecessary work. Removed the redundant call and inline variable.

## Changes
- **src/components/TOCList.astro**: Remove import and call to `filterTocHeadings`; use `headings` prop directly

## Testing
- [x] `bun run verify` passed (type-check, lint, format, test, build)