### PR TITLE
refactor: deduplicate social URLs by deriving from socialLinks

### DIFF
--- a/src/components/seo/JsonLd.astro
+++ b/src/components/seo/JsonLd.astro
@@ -119,7 +119,7 @@ if (type === "website") {
     url: SITE.url,
     jobTitle: person?.jobTitle || SITE.tagline,
     description: person?.description || SITE.tagline,
-    sameAs: [SITE.github, SITE.x, SITE.linkedin, SITE.bluesky].filter(Boolean),
+    sameAs: SITE.socialLinks.filter((l) => l.external).map((l) => l.href),
     image: SITE.avatar ? new URL(SITE.avatar, Astro.site).href : undefined,
   };
 }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -20,12 +20,6 @@ export const SITE = {
   heroIntro:
     "Based in Kochi, Kerala. I work on the backend, the part that keeps things running while everything else stays visible. Java and Spring Boot, mostly.",
 
-  // Social
-  github: "https://github.com/abijith-suresh",
-  x: "https://x.com/abijith_sh",
-  linkedin: "https://linkedin.com/in/abijith-suresh",
-  bluesky: "https://bsky.app/profile/abijith.bsky.social",
-
   // About page
   aboutSubtitle: "Backend by trade, builder by nature",
   aboutWhatIDo:


### PR DESCRIPTION
## Summary
Removed duplicate top-level social URL fields (`SITE.github`, `SITE.x`, `SITE.linkedin`, `SITE.bluesky`) that held the same URLs as entries in `SITE.socialLinks`. `JsonLd.astro` now derives the `sameAs` array from `socialLinks`, filtering to external URLs only. Single source of truth for all social profiles.

## Changes
- **src/consts.ts**: Remove duplicate top-level social URL fields
- **src/components/seo/JsonLd.astro**: Derive `sameAs` from `SITE.socialLinks` instead of hardcoded field references

## Testing
- [x] `bun run verify` passed (type-check, lint, format, test, build)