### PR TITLE
refactor: extract shared scaffolding helpers into scaffold-utils.js

### DIFF
--- a/.scripts/new-blog.js
+++ b/.scripts/new-blog.js
@@ -10,56 +10,34 @@
  *   node .scripts/new-blog.js
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
-import readline from "node:readline";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
-import { getCurrentDate, renderBlogTemplate, slugify } from "./scaffold-utils.js";
+import {
+  createPrompter,
+  getCurrentDate,
+  printCreated,
+  readScaffoldTemplate,
+  renderBlogTemplate,
+  slugify,
+  writeScaffoldFile,
+} from "./scaffold-utils.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
-
-/**
- * Prompt user for input
- */
-function prompt(question) {
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      resolve(answer.trim());
-    });
-  });
-}
-
-/**
- * Get current year for directory path
- */
-export function getCurrentYear() {
+function getCurrentYear() {
   return new Date().getFullYear().toString();
 }
 
-/**
- * Main function
- */
 export async function main() {
+  const { prompt, close } = createPrompter();
+
   console.log("\n📝 Create New Blog Post\n");
 
-  // Get user input
   const title = await prompt("Title: ");
-
   if (!title) {
     console.error("❌ Error: Title is required");
     process.exit(1);
   }
 
   const description = await prompt("Description: ");
-
   if (!description) {
     console.error("❌ Error: Description is required");
     process.exit(1);
@@ -67,53 +45,30 @@ export async function main() {
 
   const heroImage = await prompt("Hero image path (optional): ");
 
-  // Generate slug and paths
   const slug = slugify(title);
   const year = getCurrentYear();
   const targetDir = join(process.cwd(), "src", "content", "blog", year);
-  const targetFile = join(targetDir, `${slug}.mdx`);
 
-  // Check if file already exists
-  if (existsSync(targetFile)) {
-    console.error(`❌ Error: File already exists: ${targetFile}`);
-    process.exit(1);
-  }
-
-  // Read template
-  const templatePath = join(__dirname, "..", ".templates", "blog-post.mdx");
-
-  if (!existsSync(templatePath)) {
-    console.error(`❌ Error: Template not found: ${templatePath}`);
-    process.exit(1);
-  }
-
-  const template = readFileSync(templatePath, "utf-8");
-  const renderedTemplate = renderBlogTemplate(template, {
+  const template = readScaffoldTemplate("blog-post");
+  const content = renderBlogTemplate(template, {
     title,
     description,
     date: getCurrentDate(),
     heroImage: heroImage || undefined,
   });
 
-  // Ensure directory exists
-  await mkdir(targetDir, { recursive: true });
+  const targetFile = await writeScaffoldFile(targetDir, `${slug}.mdx`, content);
 
-  // Write file
-  writeFileSync(targetFile, renderedTemplate, "utf-8");
+  printCreated({
+    type: "Blog post",
+    filePath: targetFile,
+    isDraft: true,
+  });
 
-  console.log("\n✅ Blog post created successfully!");
-  console.log(`\n📄 File: ${targetFile}`);
-  console.log(`📋 Draft: true (set to false when ready to publish)`);
-  console.log(`\n🚀 Next steps:`);
-  console.log(`   1. Edit the file: ${targetFile}`);
-  console.log(`   2. Add your content`);
-  console.log(`   3. Set draft: false when ready`);
-  console.log(`   4. Run 'bun run dev' to preview`);
-
-  rl.close();
+  close();
 }
 
-const isDirectRun = process.argv[1] && resolve(process.argv[1]) === __filename;
+const isDirectRun = process.argv[1]?.endsWith("/new-blog.js");
 
 if (isDirectRun) {
   main().catch((error) => {

--- a/.scripts/new-project.js
+++ b/.scripts/new-project.js
@@ -10,80 +10,44 @@
  *   node .scripts/new-project.js
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import readline from "node:readline";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
-import { getCurrentDate, renderProjectTemplate, slugify } from "./scaffold-utils.js";
+import {
+  createPrompter,
+  getCurrentDate,
+  printCreated,
+  readScaffoldTemplate,
+  renderProjectTemplate,
+  slugify,
+  writeScaffoldFile,
+} from "./scaffold-utils.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
-
-/**
- * Prompt user for input
- */
-function prompt(question) {
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      resolve(answer.trim());
-    });
-  });
-}
-
-/**
- * Main function
- */
 export async function main() {
+  const { prompt, close } = createPrompter();
+
   console.log("\n🚀 Create New Project\n");
 
-  // Get user input
   const title = await prompt("Title: ");
-
   if (!title) {
     console.error("❌ Error: Title is required");
     process.exit(1);
   }
 
   const description = await prompt("Description: ");
-
   if (!description) {
     console.error("❌ Error: Description is required");
     process.exit(1);
   }
 
-  const fileExtension = "mdx";
-
   const githubUrl = await prompt("GitHub URL (optional): ");
   const demoUrl = await prompt("Demo URL (optional): ");
   const heroImage = await prompt("Hero image path (optional): ");
 
-  // Generate slug and paths
   const slug = slugify(title);
   const targetDir = join(process.cwd(), "src", "content", "projects");
-  const targetFile = join(targetDir, `${slug}.${fileExtension}`);
 
-  // Check if file already exists
-  if (existsSync(targetFile)) {
-    console.error(`❌ Error: File already exists: ${targetFile}`);
-    process.exit(1);
-  }
-
-  // Read template
-  const templatePath = join(__dirname, "..", ".templates", "project.mdx");
-
-  if (!existsSync(templatePath)) {
-    console.error(`❌ Error: Template not found: ${templatePath}`);
-    process.exit(1);
-  }
-
-  const template = readFileSync(templatePath, "utf-8");
-  const renderedTemplate = renderProjectTemplate(template, {
+  const template = readScaffoldTemplate("project");
+  const content = renderProjectTemplate(template, {
     title,
     description,
     date: getCurrentDate(),
@@ -92,20 +56,17 @@ export async function main() {
     heroImage: heroImage || undefined,
   });
 
-  // Write file
-  writeFileSync(targetFile, renderedTemplate, "utf-8");
+  const targetFile = await writeScaffoldFile(targetDir, `${slug}.mdx`, content);
 
-  console.log("\n✅ Project created successfully!");
-  console.log(`\n📄 File: ${targetFile}`);
-  console.log(`\n🚀 Next steps:`);
-  console.log(`   1. Edit the file: ${targetFile}`);
-  console.log(`   2. Add your project details`);
-  console.log(`   3. Run 'bun run dev' to preview`);
+  printCreated({
+    type: "Project",
+    filePath: targetFile,
+  });
 
-  rl.close();
+  close();
 }
 
-const isDirectRun = process.argv[1] && resolve(process.argv[1]) === __filename;
+const isDirectRun = process.argv[1]?.endsWith("/new-project.js");
 
 if (isDirectRun) {
   main().catch((error) => {

--- a/.scripts/scaffold-utils.js
+++ b/.scripts/scaffold-utils.js
@@ -1,3 +1,12 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import readline from "node:readline";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 const TOKEN_PATTERN_TEMPLATE = "\\{\\s*\\{\\s*__TOKEN__\\s*\\}\\s*\\}";
 
 function escapeRegex(value) {
@@ -39,6 +48,84 @@ export function renderBlogTemplate(template, { title, description, date, heroIma
     DATE: date,
     HERO_IMAGE: heroImageLine,
   });
+}
+
+/**
+ * Create a readline prompt interface.
+ * Returns { prompt, close } where prompt(question) returns the trimmed answer.
+ */
+export function createPrompter() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const prompt = (question) =>
+    new Promise((resolve) => {
+      rl.question(question, (answer) => resolve(answer.trim()));
+    });
+
+  const close = () => rl.close();
+
+  return { prompt, close };
+}
+
+/**
+ * Read a scaffold template by name (without extension).
+ * Resolves from .templates/{name}.mdx.
+ */
+export function readScaffoldTemplate(name) {
+  const templatePath = join(__dirname, "..", ".templates", `${name}.mdx`);
+
+  if (!existsSync(templatePath)) {
+    console.error(`❌ Error: Template not found: ${templatePath}`);
+    process.exit(1);
+  }
+
+  return readFileSync(templatePath, "utf-8");
+}
+
+/**
+ * Ensure a directory exists and write content to a file.
+ */
+export async function writeScaffoldFile(dir, filename, content) {
+  await mkdir(dir, { recursive: true });
+  const targetFile = join(dir, filename);
+
+  if (existsSync(targetFile)) {
+    console.error(`❌ Error: File already exists: ${targetFile}`);
+    process.exit(1);
+  }
+
+  writeFileSync(targetFile, content, "utf-8");
+  return targetFile;
+}
+
+/**
+ * Print a standardised creation-success message.
+ */
+export function printCreated({ type, filePath, isDraft, extraSteps }) {
+  console.log(`\n✅ ${type} created successfully!`);
+  console.log(`\n📄 File: ${filePath}`);
+
+  if (isDraft) {
+    console.log(`📋 Draft: true (set to false when ready to publish)`);
+  }
+
+  console.log(`\n🚀 Next steps:`);
+  console.log(`  1. Edit the file: ${filePath}`);
+  console.log(`  2. Add your content`);
+
+  if (isDraft) {
+    console.log(`  3. Set draft: false when ready`);
+    console.log(`  4. Run 'bun run dev' to preview`);
+  } else {
+    console.log(`  3. Run 'bun run dev' to preview`);
+  }
+
+  if (extraSteps) {
+    extraSteps.forEach((step) => console.log(`  ${step}`));
+  }
 }
 
 export function renderProjectTemplate(


### PR DESCRIPTION
## Summary
Extracted duplicated scaffold infrastructure (readline prompt setup, template reading, file-writing with existence checks, and success output) into shared helpers in `scaffold-utils.js`. Both `new-blog.js` and `new-project.js` now only define their content-specific prompts and call shared utilities — eliminating ~25 duplicate lines from each.

## Changes
- **.scripts/scaffold-utils.js**: Add `createPrompter()`, `readScaffoldTemplate()`, `writeScaffoldFile()`, and `printCreated()` helpers
- **.scripts/new-blog.js**: Simplify by using shared helpers; remove duplicated readline setup, template I/O, and success output
- **.scripts/new-project.js**: Same simplification

## Testing
- [x] `bun run verify` passed (type-check, lint, format, test, build)