### PR TITLE
docs: update changelog with dated entries and rewrite AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Personal portfolio and blog built with Astro.
 | ------------------------------------------------------ | ---------------------------------------------------- |
 | Content schemas (frontmatter validation)               | `src/content.config.ts`                              |
 | Site-wide config (URLs, social links, nav, pagination) | `src/consts.ts`                                      |
-| Changelog — add entries under `## [Unreleased]`        | `CHANGELOG.md`                                       |
+| Changelog — add dated entries under `## Unreleased`    | `CHANGELOG.md`                                       |
 | Scaffolding CLI scripts                                | `.scripts/new-blog.js`, `.scripts/new-project.js`    |
 | Content templates                                      | `.templates/blog-post.mdx`, `.templates/project.mdx` |
 
@@ -23,7 +23,11 @@ Browse `src/components/` and `src/lib/` for existing patterns before introducing
 ## Rules
 
 - Use `@/` path alias for all imports from `src/`.
-- Update `CHANGELOG.md` under `## [Unreleased]` with every notable change.
+- Update `CHANGELOG.md` for every notable change. Add entries under
+  `## Unreleased`, grouped by category (`### Added`, `### Changed`,
+  `### Fixed`, `### Removed`). Each category header must include today's
+  date: `### Changed — YYYY-MM-DD`. If a subsection with today's date
+  already exists, append to it instead of creating a duplicate.
 - Run `bun run verify` before every push.
 - Commit and PR titles must use Conventional Commits (`feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`).
 - Branch from the latest `main`; never commit directly to `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,47 +1,30 @@
-# Agent Instructions — abijith.sh
+# Agent Instructions
 
-## Overview
+Personal portfolio and blog built with Astro.
 
-- Personal portfolio and blog built with Astro.
-- Most changes are in content collections, Astro components, and site presentation.
+## Quick Start
 
-## Stack
+- `bun install` — install dependencies
+- `bun run dev` — start dev server
+- `bun run verify` — run type-check, lint, format check, tests, and build
 
-- Astro 6
-- TypeScript
-- Tailwind CSS v4
-- MDX
-- Bun
+## Sources of Truth
 
-## Commands
+| What                                                   | Where                                                |
+| ------------------------------------------------------ | ---------------------------------------------------- |
+| Content schemas (frontmatter validation)               | `src/content.config.ts`                              |
+| Site-wide config (URLs, social links, nav, pagination) | `src/consts.ts`                                      |
+| Changelog — add entries under `## [Unreleased]`        | `CHANGELOG.md`                                       |
+| Scaffolding CLI scripts                                | `.scripts/new-blog.js`, `.scripts/new-project.js`    |
+| Content templates                                      | `.templates/blog-post.mdx`, `.templates/project.mdx` |
 
-- Install deps: `bun install`
-- Dev server: `bun run dev`
-- Quality gate: `bun run verify`
-- Individual steps: `bun run type-check`, `bun run lint`, `bun run format:check`, `bun run test`, `bun run build`
+Browse `src/components/` and `src/lib/` for existing patterns before introducing new abstractions.
 
-## Project Map
+## Rules
 
-- `src/content.config.ts`: content collection schemas
-- `src/content/blog/`: blog posts
-- `src/content/projects/`: project entries
-- `src/components/`: Astro components and MDX helpers
-- `src/lib/`: blog, project, TOC, and utility helpers
-- `.templates/` and `.scripts/`: content scaffolding utilities
-
-## Hard Rules
-
-- Use the `@/` path alias for `src` imports.
-- Keep content frontmatter valid against `src/content.config.ts` schemas.
-- Prefer existing Astro component and content patterns over new abstractions.
-- If you change collection schemas, update affected content and validation paths together.
-
-## Git And CI
-
-- Branch from the latest `main` before starting changes.
-- Never commit directly to `main`.
-- Commit and PR titles must use Conventional Commits: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`.
-- Before push, run `bun run verify`.
-- `pre-commit` runs `lint-staged`, `commit-msg` runs `commitlint`, and `pre-push` runs `bun run verify`.
-- CI enforces `quality` and `pr-title` checks on pull requests.
+- Use `@/` path alias for all imports from `src/`.
+- Update `CHANGELOG.md` under `## [Unreleased]` with every notable change.
+- Run `bun run verify` before every push.
+- Commit and PR titles must use Conventional Commits (`feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`).
+- Branch from the latest `main`; never commit directly to `main`.
 - Squash merge is the expected merge strategy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 All notable changes to this site are documented in this file.
 
-This changelog follows the categories and intent of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), but tracks the site as a series of dated milestones instead of package releases.
-
 ## Unreleased
 
 ### Changed — 2026-05-21
@@ -20,272 +18,233 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
   CLI scripts.
 - Unexport `ContentTag`, `ScrollRevealOptions`, and `TocController` types
   that had no external consumers.
-- Standardise changelog format around dated category entries
-  (`### Changed — YYYY-MM-DD`) across the full history and rewrite
-  AGENTS.md as a lean pointer file with explicit changelog instructions.
+- Standardise changelog format around dated entries (`### Changed —
+YYYY-MM-DD`) and rewrite AGENTS.md as a lean pointer file.
 - Resolve iPhone header transparency issue near the dynamic island where
   the status bar area showed through the navigation bar.
 - FlexSearch-powered search modal, search index API endpoint, icon trigger,
   and all related infrastructure to simplify the codebase until more
   content is available.
-
-## 2026-05-21 — Swiss redesign and MDX/content architecture overhaul
-
-### Changed — 2026-05-21
-
-- A dark-only Swiss-inspired visual system with refreshed monogram/favicon assets, accent rules, noise texture, semantic MDX callout variants, scroll-reveal card motion, a mobile navigation drawer, a project TOC sidebar, and shared UI primitives such as `PageShell`, `PageHeader`, `Button`, `Tag`, `Container`, `SplitSection`, `EmptyState`, and `FooterLink`.
-- Optional `heroImage` support in both blog and project content schemas, plus an extracted `RecentProjects` homepage section and MDX-first scaffolding/templates for new content.
-- Rebuilt the home, about, blog, projects, tags, 404, header, footer, and content detail pages around a cleaner Swiss editorial grid with stronger hierarchy, simplified navigation patterns, and more consistent detail-page structure.
-- Standardized content authoring on MDX by converting existing `.md` entries, removing the old project Markdown template, updating barrel exports/imports, and refreshing template documentation and scripts to match the live schema.
-- Simplified site architecture by centralizing site constants and route construction, extracting shared content-detail, TOC, grouping, pagination, and search-result primitives, and refining helpers such as project sorting, reading progress, and tag handling.
-- Refreshed `DESIGN.md` to match the current direction and replaced brittle regex-based scaffolding with token-based template rendering.
-- Canonicalized tag pages back to slug-only routes, eliminating duplicate static outputs such as `/tags/astro` and `/tags/Astro` while keeping tag links on the canonical path.
-- Improved consistency and accessibility across breadcrumbs, tag schema guards, project ordering, mobile nav link sizing, button borders, typography scaling, Expressive Code styling, pagination empty states, and Astro/Zod structured-data hints.
-- Light mode, the theme picker, and the older theme-generation infrastructure.
-- Related-post recommendations, tag counts, detail-page back links, and other obsolete components, files, and exports that no longer fit the streamlined site structure.
-- Most automated tests, leaving a placeholder test while the redesigned codebase settles.
-
-## 2026-05-04 — Editorial refresh and Astro 6 upgrade
+- Swiss-inspired visual system with refreshed monogram/favicon assets,
+  accent rules, noise texture, semantic MDX callout variants, scroll-reveal
+  card motion, mobile navigation drawer, project TOC sidebar, and shared UI
+  primitives (`PageShell`, `PageHeader`, `Button`, `Tag`, `Container`,
+  `SplitSection`, `EmptyState`, `FooterLink`).
+- Optional `heroImage` support in both blog and project content schemas,
+  plus `RecentProjects` homepage section and MDX-first scaffolding.
+- Rebuilt home, about, blog, projects, tags, 404, header, footer, and
+  content detail pages around a Swiss editorial grid.
+- Standardized content authoring on MDX, converting existing `.md` entries.
+- Centralized site constants and route construction, extracted content-detail,
+  TOC, grouping, pagination, and search-result primitives.
+- Refreshed `DESIGN.md` and replaced regex-based scaffolding with token-based
+  template rendering.
+- Canonicalized tag pages to slug-only routes.
+- Improved consistency and accessibility across breadcrumbs, tag schemas,
+  project ordering, mobile nav, buttons, typography, code blocks, pagination
+  empty states, and structured data.
+- Removed light mode, theme picker, theme-generation infrastructure,
+  related-post recommendations, tag counts, detail-page back links, and other
+  obsolete components.
+- Removed most automated tests, leaving a placeholder.
 
 ### Changed — 2026-05-04
 
-- A Featured Projects section on the landing page, pulling project cards from the projects collection.
-- Bricolage Grotesque as the display typeface and a two-line section-label pattern pairing bold display headings with muted supporting sublabels.
-- Rewrote the homepage hero voice, spacing, accent rule, and hover affordances; replaced the clay accent with deep evergreen; refined card borders, hover motion, and dark-surface balance; and limited entrance animations to the first page load in a session.
-- Redesigned the About page layout, copy, and typography hierarchy around named narrative sections, updated role/location copy, and stronger page-title proportions.
-- Updated page and listing sublabels, section heading treatments, and `DESIGN.md` guidance to reflect the new editorial direction and typography rules.
-- Upgraded Astro to v6.2.1, updated the Vercel adapter, and aligned the content-config path and related integrations with the newer Astro APIs.
-- Restored accessible foreground contrast on the About page and removed decorative side-stripe accents that conflicted with the design system.
-- Removed a transition cascade conflict in `Link.astro` / `ContentCard.astro` that had been blocking card transform animations.
-
-## 2026-05-03 — Ink & Clay design system
+- Featured Projects section on the landing page.
+- Bricolage Grotesque as display typeface with two-line section-label pattern.
+- Rewrote homepage hero voice, spacing, accent rule, and hover affordances.
+- Replaced clay accent with deep evergreen; refined card borders and motion.
+- Limited entrance animations to first page load per session.
+- Redesigned About page layout, copy, and typography hierarchy.
+- Updated page sublabels, section headings, and `DESIGN.md`.
+- Upgraded Astro to v6.2.1 and updated the Vercel adapter.
+- Restored accessible foreground contrast on the About page.
+- Removed transition cascade conflict in `Link.astro` / `ContentCard.astro`.
 
 ### Changed — 2026-05-03
 
-- Design documentation for the Ink & Clay direction in `DESIGN.md`, `DESIGN.json`, and `PRODUCT.md`.
-- Introduced the Ink & Clay palette across light and dark themes, applying the fired-clay accent to identity surfaces and interactive states such as links, tag pills, navigation underlines, reading progress, card hovers, TOC highlights, and generated OG imagery.
-
-## 2026-05-01 — Repository metadata cleanup
+- Design documentation for Ink & Clay direction (`DESIGN.md`, `DESIGN.json`,
+  `PRODUCT.md`).
+- Introduced Ink & Clay palette across light and dark themes — links, tag
+  pills, navigation underlines, reading progress, card hovers, TOC highlights,
+  and OG imagery.
 
 ### Changed — 2026-05-01
 
-- Removed release automation, Git tags, and release-oriented package metadata from the repository.
-- Reframed project history as a manual dated changelog instead of GitHub release notes.
-- Removed stale GitHub Pages configuration and aligned the repository homepage with the custom domain.
-
-## 2026-04-08 — Workspace setup refresh
+- Removed release automation, Git tags, and release-oriented package metadata.
+- Reframed project history as a manual dated changelog.
+- Removed stale GitHub Pages configuration.
 
 ### Changed — 2026-04-08
 
-- Standardized workspace setup files, editor recommendations, and ignore rules for a more consistent local development environment.
-
-## 2026-04-07 — Quality gate standardization
+- Standardized workspace setup files, editor recommendations, and ignore rules.
 
 ### Changed — 2026-04-07
 
-- Standardized CI quality gates, PR title validation, and pre-push verification around `bun run verify`.
-- Simplified agent instructions and refreshed repository automation to match the current Astro workflow.
-
-## 2026-03-24 — Vercel migration
+- Standardized CI quality gates, PR title validation, and pre-push verification
+  around `bun run verify`.
+- Simplified agent instructions for the Astro workflow.
 
 ### Changed — 2026-03-24
 
-- Migrated deployment from GitHub Pages to Vercel for the `abijith.sh` custom domain.
-- Renamed the repository to `abijith.sh` and aligned canonical site references around that identity.
+- Migrated deployment from GitHub Pages to Vercel for `abijith.sh`.
+- Renamed the repository to `abijith.sh`.
 - Prevented draft blog posts from being generated as public pages.
-- Restored Astro-aware type checking in CI and added regression coverage for launch readiness.
-
-## 2026-02-21 — Configuration sync
+- Restored Astro-aware type checking in CI.
 
 ### Changed — 2026-02-21
 
-- Synchronized repository configuration and shared project standards with the latest personal workspace conventions.
-
-## 2026-02-14 — Dynamic OG image generation
+- Synchronized repository configuration with personal workspace conventions.
 
 ### Changed — 2026-02-14
 
-- Dynamic OG image generation matching the Ink and Paper theme for richer social sharing.
-- Extended page metadata so the blog and project pages could use generated social preview images.
-
-## 2026-02-12 — Real content and about-page refinement
+- Dynamic OG image generation matching the Ink and Paper theme.
+- Extended page metadata for social preview images.
 
 ### Changed — 2026-02-12
 
-- Initial real portfolio and blog content to replace the earlier placeholder-heavy site.
-- Redesigned the About page with a centered layout, labeled sections, and more personal content.
-- Removed dummy blog posts and projects that no longer reflected the live site.
-- Handled empty-content states more gracefully across listing pages.
-
-## 2026-02-11 — Content scaffolding and site history
+- Initial real portfolio and blog content replacing placeholder-heavy site.
+- Redesigned About page with centered layout and labeled sections.
+- Removed dummy blog posts and projects.
+- Handled empty-content states across listing pages.
 
 ### Changed — 2026-02-11
 
-- Content templates and creation scripts for new blog posts and projects.
-- A project changelog to track the Astro-era history of the site.
-
-## 2026-02-10 — Content-model and UI cleanup
+- Content templates and creation scripts for blog posts and projects.
+- Project changelog tracking the Astro-era history.
 
 ### Changed — 2026-02-10
 
-- Font Awesome social icons to better match the visual language of the site.
-- Improved content collection schemas and cleaned up code structure and comments to make the codebase easier to maintain.
-
-## 2026-02-06 — Ink and Paper redesign
+- Font Awesome social icons.
+- Improved content collection schemas and code structure.
 
 ### Changed — 2026-02-06
 
-- The Ink and Paper visual theme with editorial styling, a custom palette, updated typography, and refreshed theme assets.
-- Reworked the header, cards, search experience, tag pages, and site-wide styling around the new theme direction.
-
-## 2026-02-01 — Search and content organization
+- Ink and Paper visual theme with editorial styling, custom palette, updated
+  typography, and refreshed assets.
+- Reworked header, cards, search, tag pages, and site-wide styling.
 
 ### Changed — 2026-02-01
 
-- FlexSearch-powered search, a JSON search index endpoint, year-based blog organization, dual licensing, and refreshed DevContainer support.
-- A custom Dockerfile and updated container setup for more consistent development environments.
-- Replaced Pagefind with FlexSearch and improved the shared search architecture.
-- Rewrote the README to better reflect the more personal direction of the site.
-
-## 2026-01-31 — Search empty-state polish
+- FlexSearch-powered search, JSON search index endpoint, year-based blog
+  organization, dual licensing, DevContainer support, and custom Dockerfile.
+- Replaced Pagefind with FlexSearch.
+- Rewrote README for the personal site direction.
 
 ### Changed — 2026-01-31
 
-- A branded empty state for zero-result searches.
-
-## 2026-01-28 — CI hardening and feed reliability
+- Branded empty state for zero-result searches.
 
 ### Changed — 2026-01-28
 
-- Updated social profile links to better reflect the current public presence of the site owner.
-- Tightened CI with stronger type checking and refreshed dependency automation.
-- Added more robust RSS generation error handling.
-
-## 2026-01-26 — Publishing and documentation refinements
+- Updated social profile links.
+- Tightened CI with stronger type checking.
+- Added robust RSS generation error handling.
 
 ### Changed — 2026-01-26
 
-- Comprehensive README documentation for running, understanding, and contributing to the Astro site.
-- A simplified two-option theme toggle with smoother theme transitions.
-- Extracted shared tag utilities and search modal logic to reduce duplication.
+- Comprehensive README documentation.
+- Simplified two-option theme toggle with smoother transitions.
+- Extracted shared tag utilities and search modal logic.
 - Cleaned up semantic wrappers and centralized transition-duration styling.
-- Disabled Jekyll processing on GitHub Pages during the Astro deployment phase.
-- Normalized tag casing to avoid duplicates in search and tag pages.
-- Corrected the sitemap URL to match the canonical site URL.
-
-## 2026-01-25 — GitHub Pages rollout
+- Disabled Jekyll processing on GitHub Pages.
+- Normalized tag casing to avoid duplicates.
+- Corrected sitemap URL to canonical site URL.
 
 ### Changed — 2026-01-25
 
-- Switched deployment from Vercel to GitHub Pages during the early Astro rollout.
-- Removed Vercel analytics and updated site settings to work from the repository-hosted deployment.
-
-## 2026-01-24 — Search and tag discovery improvements
+- Switched deployment from Vercel to GitHub Pages.
+- Removed Vercel analytics.
 
 ### Changed — 2026-01-24
 
-- Tag pages that combine both blog posts and projects.
-- Search results that surface tags alongside titles and descriptions.
-- A broader set of search modal improvements for discovery and usability.
-- Refactored shared content patterns and smoothed out SPA-like page motion.
-- Improved navigation consistency across tag pages and related flows.
-- Closed the search modal after selecting a result.
-- Fixed missing color variables and transition settings in light and dark modes.
-- Corrected a structured-data reference in the JsonLd component.
-
-## 2026-01-23 — UX and codebase cleanup
+- Tag pages combining blog posts and projects.
+- Search results surfacing tags alongside titles and descriptions.
+- Search modal improvements for discovery and usability.
+- Refactored shared content patterns and SPA-like page motion.
+- Improved navigation consistency across tag pages.
+- Closed search modal after selecting a result.
+- Fixed missing color variables in light and dark modes.
+- Corrected structured-data reference in JsonLd.
 
 ### Changed — 2026-01-23
 
-- DevContainer support for more reproducible development setups.
-- Additional home, footer, and layout refinements to improve the reading experience.
-- Extracted components and improved accessibility, SEO, and general code quality across the site.
-- Removed the unused LinkCard MDX component.
-- Fixed event-listener leaks in the theme picker and search modal.
-- Closed a batch of small UX and maintainability issues across the codebase.
-
-## 2026-01-22 — Breadcrumbs, tags, and modal search
+- DevContainer support.
+- Home, footer, and layout refinements.
+- Extracted components, improved accessibility and SEO.
+- Removed unused LinkCard MDX component.
+- Fixed event-listener leaks in theme picker and search modal.
+- Closed batch of small UX and maintainability issues.
 
 ### Changed — 2026-01-22
 
 - Breadcrumb navigation across the site.
-- An all-tags page for discovery.
-- A modal-based search experience with an icon trigger.
-- Improved the search modal UI and made tag pages more flexible in layout and navigation.
-- Corrected header alignment around the logo and theme toggle.
-- Fixed breadcrumb structure on tag pages.
-
-## 2026-01-21 — Discovery and editorial redesign
+- All-tags page for discovery.
+- Modal-based search experience with icon trigger.
+- Improved search modal UI and tag page layouts.
+- Corrected header alignment and breadcrumb structure on tag pages.
 
 ### Changed — 2026-01-21
 
-- Related-post recommendations, Pagefind search, Vercel analytics, and richer code-block line-number configuration.
-- Redesigned the home and about pages toward a cleaner, more personal editorial layout.
-- Removed images from cards and detail pages for a more minimal presentation.
-
-## 2026-01-17 — Automation and reading experience
+- Related-post recommendations, Pagefind search, Vercel analytics, richer
+  code-block line-number configuration.
+- Redesigned home and about pages toward cleaner editorial layout.
+- Removed images from cards and detail pages.
 
 ### Changed — 2026-01-17
 
-- CI automation, Dependabot updates, pre-commit hooks, dark-mode refinements, a reading-progress indicator, and additional static assets.
-- Simplified agent instructions and removed obsolete image-generation tooling.
-- Added the missing RSS dependency required by the Astro site.
-
-## 2026-01-16 — Astro rewrite milestone
+- CI automation, Dependabot updates, pre-commit hooks, dark-mode refinements,
+  reading-progress indicator, static assets.
+- Simplified agent instructions, removed obsolete image-generation tooling.
+- Added missing RSS dependency.
 
 ### Changed — 2026-01-16
 
-- Consolidated the Astro rewrite into a stable milestone after the initial migration, publishing, and MDX groundwork landed.
-
-## 2026-01-15 — MDX and writing experience
+- Consolidated Astro rewrite milestone after migration, publishing, and MDX
+  groundwork landed.
 
 ### Changed — 2026-01-15
 
 - Reading-time calculation for posts.
 - MDX support with Expressive Code and improved typography.
 - Callout, image, video, and richer MDX content components.
-- A table of contents with both header and sidebar treatments.
-- Refreshed agent documentation and removed obsolete planning files that no longer matched the site workflow.
-- Removed heading anchor links to simplify the reading experience.
+- Table of contents with header and sidebar treatments.
+- Refreshed agent documentation, removed obsolete planning files.
+- Removed heading anchor links.
 - Resolved MDX build, lint, and formatting issues.
-- Improved LinkCard and typography styling for readability.
-
-## 2026-01-12 — SEO and publishing foundations
+- Improved LinkCard and typography styling.
 
 ### Changed — 2026-01-12
 
-- RSS feed generation, sitemap generation, robots.txt, a custom 404 page, a footer, structured SEO, and view transitions.
-- Simplified blog and project cards into a more text-first layout.
-- Improved navigation prefetching and other performance-oriented behavior.
+- RSS feed generation, sitemap, robots.txt, custom 404 page, footer,
+  structured SEO, view transitions.
+- Simplified blog and project cards into text-first layout.
+- Improved navigation prefetching.
 - Resolved early linting and formatting issues.
 - Tightened type annotations for article authors and tags.
 
-## 2026-01-10 — Blog, about page, and local tooling
-
 ### Changed — 2026-01-10
 
-- Blog cards, blog and tag pagination, paginated project routes, recent-posts and recent-projects sections, a skills module, a timeline module, and a richer About page.
-- ESLint and Prettier configuration, updated package scripts, and better VS Code recommendations for local development.
-- Dedicated agent guidance for working on the Astro codebase.
-- Improved project-card responsiveness and tidied utility styling.
-- Resolved early build, linting, and formatting issues in the Astro codebase.
-
-## 2026-01-09 — Content collections and dynamic project pages
+- Blog cards, blog and tag pagination, paginated project routes,
+  recent-posts and recent-projects sections, skills module, timeline module,
+  richer About page.
+- ESLint and Prettier config, package scripts, VS Code recommendations.
+- Dedicated agent guidance for the Astro codebase.
+- Improved project-card responsiveness.
+- Resolved early build, linting, and formatting issues.
 
 ### Changed — 2026-01-09
 
 - Zod-backed content collections for blog posts and projects.
-- Dynamic project listings, project-detail pages, and shared data utilities for content management.
-- Initial seed content to exercise the new Astro content model.
+- Dynamic project listings, project-detail pages, shared data utilities.
+- Initial seed content to exercise the Astro content model.
 - Replaced placeholder homepage content with dynamic recent-project flows.
-- Simplified project metadata by removing the old featured and ordering fields.
-
-## 2026-01-04 — Astro reboot
+- Simplified project metadata.
 
 ### Changed — 2026-01-04
 
-- A new Astro + Bun foundation for the site.
-- Tailwind CSS, shared site configuration, navigation links, social links, header and hero primitives, theming support, and early homepage project scaffolding.
-- Path aliases and styling improvements to support the new Astro architecture.
-- Reoriented the repository around the Astro implementation and updated the README to match the new stack.
-- The previous Next.js codebase, workflows, configs, and app-router implementation.
+- Astro + Bun foundation, Tailwind CSS, shared site configuration,
+  navigation links, social links, header and hero primitives, theming support,
+  homepage project scaffolding, path aliases.
+- Reoriented repository around Astro; updated README.
+- Removed previous Next.js codebase, workflows, configs, and app-router.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
   CLI scripts.
 - Unexport `ContentTag`, `ScrollRevealOptions`, and `TocController` types
   that had no external consumers.
+- Standardise changelog format around dated category entries
+  (`### Changed — YYYY-MM-DD`) across the full history and rewrite
+  AGENTS.md as a lean pointer file with explicit changelog instructions.
 
 ### Fixed — 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,24 +34,24 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## 2026-05-21 — Swiss redesign and MDX/content architecture overhaul
 
-### Added
+### Added — 2026-05-21
 
 - A dark-only Swiss-inspired visual system with refreshed monogram/favicon assets, accent rules, noise texture, semantic MDX callout variants, scroll-reveal card motion, a mobile navigation drawer, a project TOC sidebar, and shared UI primitives such as `PageShell`, `PageHeader`, `Button`, `Tag`, `Container`, `SplitSection`, `EmptyState`, and `FooterLink`.
 - Optional `heroImage` support in both blog and project content schemas, plus an extracted `RecentProjects` homepage section and MDX-first scaffolding/templates for new content.
 
-### Changed
+### Changed — 2026-05-21
 
 - Rebuilt the home, about, blog, projects, tags, 404, header, footer, and content detail pages around a cleaner Swiss editorial grid with stronger hierarchy, simplified navigation patterns, and more consistent detail-page structure.
 - Standardized content authoring on MDX by converting existing `.md` entries, removing the old project Markdown template, updating barrel exports/imports, and refreshing template documentation and scripts to match the live schema.
 - Simplified site architecture by centralizing site constants and route construction, extracting shared content-detail, TOC, grouping, pagination, and search-result primitives, and refining helpers such as project sorting, reading progress, and tag handling.
 - Refreshed `DESIGN.md` to match the current direction and replaced brittle regex-based scaffolding with token-based template rendering.
 
-### Fixed
+### Fixed — 2026-05-21
 
 - Canonicalized tag pages back to slug-only routes, eliminating duplicate static outputs such as `/tags/astro` and `/tags/Astro` while keeping tag links on the canonical path.
 - Improved consistency and accessibility across breadcrumbs, tag schema guards, project ordering, mobile nav link sizing, button borders, typography scaling, Expressive Code styling, pagination empty states, and Astro/Zod structured-data hints.
 
-### Removed
+### Removed — 2026-05-21
 
 - Light mode, the theme picker, and the older theme-generation infrastructure.
 - Related-post recommendations, tag counts, detail-page back links, and other obsolete components, files, and exports that no longer fit the streamlined site structure.
@@ -59,172 +59,172 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## 2026-05-04 — Editorial refresh and Astro 6 upgrade
 
-### Added
+### Added — 2026-05-04
 
 - A Featured Projects section on the landing page, pulling project cards from the projects collection.
 - Bricolage Grotesque as the display typeface and a two-line section-label pattern pairing bold display headings with muted supporting sublabels.
 
-### Changed
+### Changed — 2026-05-04
 
 - Rewrote the homepage hero voice, spacing, accent rule, and hover affordances; replaced the clay accent with deep evergreen; refined card borders, hover motion, and dark-surface balance; and limited entrance animations to the first page load in a session.
 - Redesigned the About page layout, copy, and typography hierarchy around named narrative sections, updated role/location copy, and stronger page-title proportions.
 - Updated page and listing sublabels, section heading treatments, and `DESIGN.md` guidance to reflect the new editorial direction and typography rules.
 - Upgraded Astro to v6.2.1, updated the Vercel adapter, and aligned the content-config path and related integrations with the newer Astro APIs.
 
-### Fixed
+### Fixed — 2026-05-04
 
 - Restored accessible foreground contrast on the About page and removed decorative side-stripe accents that conflicted with the design system.
 - Removed a transition cascade conflict in `Link.astro` / `ContentCard.astro` that had been blocking card transform animations.
 
 ## 2026-05-03 — Ink & Clay design system
 
-### Added
+### Added — 2026-05-03
 
 - Design documentation for the Ink & Clay direction in `DESIGN.md`, `DESIGN.json`, and `PRODUCT.md`.
 
-### Changed
+### Changed — 2026-05-03
 
 - Introduced the Ink & Clay palette across light and dark themes, applying the fired-clay accent to identity surfaces and interactive states such as links, tag pills, navigation underlines, reading progress, card hovers, TOC highlights, and generated OG imagery.
 
 ## 2026-05-01 — Repository metadata cleanup
 
-### Changed
+### Changed — 2026-05-01
 
 - Removed release automation, Git tags, and release-oriented package metadata from the repository.
 - Reframed project history as a manual dated changelog instead of GitHub release notes.
 
-### Fixed
+### Fixed — 2026-05-01
 
 - Removed stale GitHub Pages configuration and aligned the repository homepage with the custom domain.
 
 ## 2026-04-08 — Workspace setup refresh
 
-### Changed
+### Changed — 2026-04-08
 
 - Standardized workspace setup files, editor recommendations, and ignore rules for a more consistent local development environment.
 
 ## 2026-04-07 — Quality gate standardization
 
-### Changed
+### Changed — 2026-04-07
 
 - Standardized CI quality gates, PR title validation, and pre-push verification around `bun run verify`.
 - Simplified agent instructions and refreshed repository automation to match the current Astro workflow.
 
 ## 2026-03-24 — Vercel migration
 
-### Changed
+### Changed — 2026-03-24
 
 - Migrated deployment from GitHub Pages to Vercel for the `abijith.sh` custom domain.
 - Renamed the repository to `abijith.sh` and aligned canonical site references around that identity.
 
-### Fixed
+### Fixed — 2026-03-24
 
 - Prevented draft blog posts from being generated as public pages.
 - Restored Astro-aware type checking in CI and added regression coverage for launch readiness.
 
 ## 2026-02-21 — Configuration sync
 
-### Changed
+### Changed — 2026-02-21
 
 - Synchronized repository configuration and shared project standards with the latest personal workspace conventions.
 
 ## 2026-02-14 — Dynamic OG image generation
 
-### Added
+### Added — 2026-02-14
 
 - Dynamic OG image generation matching the Ink and Paper theme for richer social sharing.
 
-### Changed
+### Changed — 2026-02-14
 
 - Extended page metadata so the blog and project pages could use generated social preview images.
 
 ## 2026-02-12 — Real content and about-page refinement
 
-### Added
+### Added — 2026-02-12
 
 - Initial real portfolio and blog content to replace the earlier placeholder-heavy site.
 
-### Changed
+### Changed — 2026-02-12
 
 - Redesigned the About page with a centered layout, labeled sections, and more personal content.
 
-### Fixed
+### Fixed — 2026-02-12
 
 - Removed dummy blog posts and projects that no longer reflected the live site.
 - Handled empty-content states more gracefully across listing pages.
 
 ## 2026-02-11 — Content scaffolding and site history
 
-### Added
+### Added — 2026-02-11
 
 - Content templates and creation scripts for new blog posts and projects.
 - A project changelog to track the Astro-era history of the site.
 
 ## 2026-02-10 — Content-model and UI cleanup
 
-### Added
+### Added — 2026-02-10
 
 - Font Awesome social icons to better match the visual language of the site.
 
-### Changed
+### Changed — 2026-02-10
 
 - Improved content collection schemas and cleaned up code structure and comments to make the codebase easier to maintain.
 
 ## 2026-02-06 — Ink and Paper redesign
 
-### Added
+### Added — 2026-02-06
 
 - The Ink and Paper visual theme with editorial styling, a custom palette, updated typography, and refreshed theme assets.
 
-### Changed
+### Changed — 2026-02-06
 
 - Reworked the header, cards, search experience, tag pages, and site-wide styling around the new theme direction.
 
 ## 2026-02-01 — Search and content organization
 
-### Added
+### Added — 2026-02-01
 
 - FlexSearch-powered search, a JSON search index endpoint, year-based blog organization, dual licensing, and refreshed DevContainer support.
 - A custom Dockerfile and updated container setup for more consistent development environments.
 
-### Changed
+### Changed — 2026-02-01
 
 - Replaced Pagefind with FlexSearch and improved the shared search architecture.
 - Rewrote the README to better reflect the more personal direction of the site.
 
 ## 2026-01-31 — Search empty-state polish
 
-### Added
+### Added — 2026-01-31
 
 - A branded empty state for zero-result searches.
 
 ## 2026-01-28 — CI hardening and feed reliability
 
-### Added
+### Added — 2026-01-28
 
 - Updated social profile links to better reflect the current public presence of the site owner.
 
-### Changed
+### Changed — 2026-01-28
 
 - Tightened CI with stronger type checking and refreshed dependency automation.
 
-### Fixed
+### Fixed — 2026-01-28
 
 - Added more robust RSS generation error handling.
 
 ## 2026-01-26 — Publishing and documentation refinements
 
-### Added
+### Added — 2026-01-26
 
 - Comprehensive README documentation for running, understanding, and contributing to the Astro site.
 - A simplified two-option theme toggle with smoother theme transitions.
 
-### Changed
+### Changed — 2026-01-26
 
 - Extracted shared tag utilities and search modal logic to reduce duplication.
 - Cleaned up semantic wrappers and centralized transition-duration styling.
 
-### Fixed
+### Fixed — 2026-01-26
 
 - Disabled Jekyll processing on GitHub Pages during the Astro deployment phase.
 - Normalized tag casing to avoid duplicates in search and tag pages.
@@ -232,25 +232,25 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## 2026-01-25 — GitHub Pages rollout
 
-### Changed
+### Changed — 2026-01-25
 
 - Switched deployment from Vercel to GitHub Pages during the early Astro rollout.
 - Removed Vercel analytics and updated site settings to work from the repository-hosted deployment.
 
 ## 2026-01-24 — Search and tag discovery improvements
 
-### Added
+### Added — 2026-01-24
 
 - Tag pages that combine both blog posts and projects.
 - Search results that surface tags alongside titles and descriptions.
 - A broader set of search modal improvements for discovery and usability.
 
-### Changed
+### Changed — 2026-01-24
 
 - Refactored shared content patterns and smoothed out SPA-like page motion.
 - Improved navigation consistency across tag pages and related flows.
 
-### Fixed
+### Fixed — 2026-01-24
 
 - Closed the search modal after selecting a result.
 - Fixed missing color variables and transition settings in light and dark modes.
@@ -258,16 +258,16 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## 2026-01-23 — UX and codebase cleanup
 
-### Added
+### Added — 2026-01-23
 
 - DevContainer support for more reproducible development setups.
 - Additional home, footer, and layout refinements to improve the reading experience.
 
-### Changed
+### Changed — 2026-01-23
 
 - Extracted components and improved accessibility, SEO, and general code quality across the site.
 
-### Fixed
+### Fixed — 2026-01-23
 
 - Removed the unused LinkCard MDX component.
 - Fixed event-listener leaks in the theme picker and search modal.
@@ -275,128 +275,128 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## 2026-01-22 — Breadcrumbs, tags, and modal search
 
-### Added
+### Added — 2026-01-22
 
 - Breadcrumb navigation across the site.
 - An all-tags page for discovery.
 - A modal-based search experience with an icon trigger.
 
-### Changed
+### Changed — 2026-01-22
 
 - Improved the search modal UI and made tag pages more flexible in layout and navigation.
 
-### Fixed
+### Fixed — 2026-01-22
 
 - Corrected header alignment around the logo and theme toggle.
 - Fixed breadcrumb structure on tag pages.
 
 ## 2026-01-21 — Discovery and editorial redesign
 
-### Added
+### Added — 2026-01-21
 
 - Related-post recommendations, Pagefind search, Vercel analytics, and richer code-block line-number configuration.
 
-### Changed
+### Changed — 2026-01-21
 
 - Redesigned the home and about pages toward a cleaner, more personal editorial layout.
 - Removed images from cards and detail pages for a more minimal presentation.
 
 ## 2026-01-17 — Automation and reading experience
 
-### Added
+### Added — 2026-01-17
 
 - CI automation, Dependabot updates, pre-commit hooks, dark-mode refinements, a reading-progress indicator, and additional static assets.
 
-### Changed
+### Changed — 2026-01-17
 
 - Simplified agent instructions and removed obsolete image-generation tooling.
 
-### Fixed
+### Fixed — 2026-01-17
 
 - Added the missing RSS dependency required by the Astro site.
 
 ## 2026-01-16 — Astro rewrite milestone
 
-### Changed
+### Changed — 2026-01-16
 
 - Consolidated the Astro rewrite into a stable milestone after the initial migration, publishing, and MDX groundwork landed.
 
 ## 2026-01-15 — MDX and writing experience
 
-### Added
+### Added — 2026-01-15
 
 - Reading-time calculation for posts.
 - MDX support with Expressive Code and improved typography.
 - Callout, image, video, and richer MDX content components.
 - A table of contents with both header and sidebar treatments.
 
-### Changed
+### Changed — 2026-01-15
 
 - Refreshed agent documentation and removed obsolete planning files that no longer matched the site workflow.
 - Removed heading anchor links to simplify the reading experience.
 
-### Fixed
+### Fixed — 2026-01-15
 
 - Resolved MDX build, lint, and formatting issues.
 - Improved LinkCard and typography styling for readability.
 
 ## 2026-01-12 — SEO and publishing foundations
 
-### Added
+### Added — 2026-01-12
 
 - RSS feed generation, sitemap generation, robots.txt, a custom 404 page, a footer, structured SEO, and view transitions.
 
-### Changed
+### Changed — 2026-01-12
 
 - Simplified blog and project cards into a more text-first layout.
 - Improved navigation prefetching and other performance-oriented behavior.
 
-### Fixed
+### Fixed — 2026-01-12
 
 - Resolved early linting and formatting issues.
 - Tightened type annotations for article authors and tags.
 
 ## 2026-01-10 — Blog, about page, and local tooling
 
-### Added
+### Added — 2026-01-10
 
 - Blog cards, blog and tag pagination, paginated project routes, recent-posts and recent-projects sections, a skills module, a timeline module, and a richer About page.
 - ESLint and Prettier configuration, updated package scripts, and better VS Code recommendations for local development.
 - Dedicated agent guidance for working on the Astro codebase.
 
-### Changed
+### Changed — 2026-01-10
 
 - Improved project-card responsiveness and tidied utility styling.
 
-### Fixed
+### Fixed — 2026-01-10
 
 - Resolved early build, linting, and formatting issues in the Astro codebase.
 
 ## 2026-01-09 — Content collections and dynamic project pages
 
-### Added
+### Added — 2026-01-09
 
 - Zod-backed content collections for blog posts and projects.
 - Dynamic project listings, project-detail pages, and shared data utilities for content management.
 - Initial seed content to exercise the new Astro content model.
 
-### Changed
+### Changed — 2026-01-09
 
 - Replaced placeholder homepage content with dynamic recent-project flows.
 - Simplified project metadata by removing the old featured and ordering fields.
 
 ## 2026-01-04 — Astro reboot
 
-### Added
+### Added — 2026-01-04
 
 - A new Astro + Bun foundation for the site.
 - Tailwind CSS, shared site configuration, navigation links, social links, header and hero primitives, theming support, and early homepage project scaffolding.
 - Path aliases and styling improvements to support the new Astro architecture.
 
-### Removed
-
-- The previous Next.js codebase, workflows, configs, and app-router implementation.
-
-### Changed
+### Changed — 2026-01-04
 
 - Reoriented the repository around the Astro implementation and updated the README to match the new stack.
+
+### Removed — 2026-01-04
+
+- The previous Next.js codebase, workflows, configs, and app-router implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,70 +23,46 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 - Standardise changelog format around dated category entries
   (`### Changed — YYYY-MM-DD`) across the full history and rewrite
   AGENTS.md as a lean pointer file with explicit changelog instructions.
-
-### Fixed — 2026-05-21
-
 - Resolve iPhone header transparency issue near the dynamic island where
   the status bar area showed through the navigation bar.
-
-### Removed — 2026-05-21
-
 - FlexSearch-powered search modal, search index API endpoint, icon trigger,
   and all related infrastructure to simplify the codebase until more
   content is available.
 
 ## 2026-05-21 — Swiss redesign and MDX/content architecture overhaul
 
-### Added — 2026-05-21
+### Changed — 2026-05-21
 
 - A dark-only Swiss-inspired visual system with refreshed monogram/favicon assets, accent rules, noise texture, semantic MDX callout variants, scroll-reveal card motion, a mobile navigation drawer, a project TOC sidebar, and shared UI primitives such as `PageShell`, `PageHeader`, `Button`, `Tag`, `Container`, `SplitSection`, `EmptyState`, and `FooterLink`.
 - Optional `heroImage` support in both blog and project content schemas, plus an extracted `RecentProjects` homepage section and MDX-first scaffolding/templates for new content.
-
-### Changed — 2026-05-21
-
 - Rebuilt the home, about, blog, projects, tags, 404, header, footer, and content detail pages around a cleaner Swiss editorial grid with stronger hierarchy, simplified navigation patterns, and more consistent detail-page structure.
 - Standardized content authoring on MDX by converting existing `.md` entries, removing the old project Markdown template, updating barrel exports/imports, and refreshing template documentation and scripts to match the live schema.
 - Simplified site architecture by centralizing site constants and route construction, extracting shared content-detail, TOC, grouping, pagination, and search-result primitives, and refining helpers such as project sorting, reading progress, and tag handling.
 - Refreshed `DESIGN.md` to match the current direction and replaced brittle regex-based scaffolding with token-based template rendering.
-
-### Fixed — 2026-05-21
-
 - Canonicalized tag pages back to slug-only routes, eliminating duplicate static outputs such as `/tags/astro` and `/tags/Astro` while keeping tag links on the canonical path.
 - Improved consistency and accessibility across breadcrumbs, tag schema guards, project ordering, mobile nav link sizing, button borders, typography scaling, Expressive Code styling, pagination empty states, and Astro/Zod structured-data hints.
-
-### Removed — 2026-05-21
-
 - Light mode, the theme picker, and the older theme-generation infrastructure.
 - Related-post recommendations, tag counts, detail-page back links, and other obsolete components, files, and exports that no longer fit the streamlined site structure.
 - Most automated tests, leaving a placeholder test while the redesigned codebase settles.
 
 ## 2026-05-04 — Editorial refresh and Astro 6 upgrade
 
-### Added — 2026-05-04
+### Changed — 2026-05-04
 
 - A Featured Projects section on the landing page, pulling project cards from the projects collection.
 - Bricolage Grotesque as the display typeface and a two-line section-label pattern pairing bold display headings with muted supporting sublabels.
-
-### Changed — 2026-05-04
-
 - Rewrote the homepage hero voice, spacing, accent rule, and hover affordances; replaced the clay accent with deep evergreen; refined card borders, hover motion, and dark-surface balance; and limited entrance animations to the first page load in a session.
 - Redesigned the About page layout, copy, and typography hierarchy around named narrative sections, updated role/location copy, and stronger page-title proportions.
 - Updated page and listing sublabels, section heading treatments, and `DESIGN.md` guidance to reflect the new editorial direction and typography rules.
 - Upgraded Astro to v6.2.1, updated the Vercel adapter, and aligned the content-config path and related integrations with the newer Astro APIs.
-
-### Fixed — 2026-05-04
-
 - Restored accessible foreground contrast on the About page and removed decorative side-stripe accents that conflicted with the design system.
 - Removed a transition cascade conflict in `Link.astro` / `ContentCard.astro` that had been blocking card transform animations.
 
 ## 2026-05-03 — Ink & Clay design system
 
-### Added — 2026-05-03
-
-- Design documentation for the Ink & Clay direction in `DESIGN.md`, `DESIGN.json`, and `PRODUCT.md`.
-
 ### Changed — 2026-05-03
 
+- Design documentation for the Ink & Clay direction in `DESIGN.md`, `DESIGN.json`, and `PRODUCT.md`.
 - Introduced the Ink & Clay palette across light and dark themes, applying the fired-clay accent to identity surfaces and interactive states such as links, tag pills, navigation underlines, reading progress, card hovers, TOC highlights, and generated OG imagery.
 
 ## 2026-05-01 — Repository metadata cleanup
@@ -95,9 +71,6 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 - Removed release automation, Git tags, and release-oriented package metadata from the repository.
 - Reframed project history as a manual dated changelog instead of GitHub release notes.
-
-### Fixed — 2026-05-01
-
 - Removed stale GitHub Pages configuration and aligned the repository homepage with the custom domain.
 
 ## 2026-04-08 — Workspace setup refresh
@@ -119,9 +92,6 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 - Migrated deployment from GitHub Pages to Vercel for the `abijith.sh` custom domain.
 - Renamed the repository to `abijith.sh` and aligned canonical site references around that identity.
-
-### Fixed — 2026-03-24
-
 - Prevented draft blog posts from being generated as public pages.
 - Restored Astro-aware type checking in CI and added regression coverage for launch readiness.
 
@@ -133,102 +103,72 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## 2026-02-14 — Dynamic OG image generation
 
-### Added — 2026-02-14
-
-- Dynamic OG image generation matching the Ink and Paper theme for richer social sharing.
-
 ### Changed — 2026-02-14
 
+- Dynamic OG image generation matching the Ink and Paper theme for richer social sharing.
 - Extended page metadata so the blog and project pages could use generated social preview images.
 
 ## 2026-02-12 — Real content and about-page refinement
 
-### Added — 2026-02-12
-
-- Initial real portfolio and blog content to replace the earlier placeholder-heavy site.
-
 ### Changed — 2026-02-12
 
+- Initial real portfolio and blog content to replace the earlier placeholder-heavy site.
 - Redesigned the About page with a centered layout, labeled sections, and more personal content.
-
-### Fixed — 2026-02-12
-
 - Removed dummy blog posts and projects that no longer reflected the live site.
 - Handled empty-content states more gracefully across listing pages.
 
 ## 2026-02-11 — Content scaffolding and site history
 
-### Added — 2026-02-11
+### Changed — 2026-02-11
 
 - Content templates and creation scripts for new blog posts and projects.
 - A project changelog to track the Astro-era history of the site.
 
 ## 2026-02-10 — Content-model and UI cleanup
 
-### Added — 2026-02-10
-
-- Font Awesome social icons to better match the visual language of the site.
-
 ### Changed — 2026-02-10
 
+- Font Awesome social icons to better match the visual language of the site.
 - Improved content collection schemas and cleaned up code structure and comments to make the codebase easier to maintain.
 
 ## 2026-02-06 — Ink and Paper redesign
 
-### Added — 2026-02-06
-
-- The Ink and Paper visual theme with editorial styling, a custom palette, updated typography, and refreshed theme assets.
-
 ### Changed — 2026-02-06
 
+- The Ink and Paper visual theme with editorial styling, a custom palette, updated typography, and refreshed theme assets.
 - Reworked the header, cards, search experience, tag pages, and site-wide styling around the new theme direction.
 
 ## 2026-02-01 — Search and content organization
 
-### Added — 2026-02-01
+### Changed — 2026-02-01
 
 - FlexSearch-powered search, a JSON search index endpoint, year-based blog organization, dual licensing, and refreshed DevContainer support.
 - A custom Dockerfile and updated container setup for more consistent development environments.
-
-### Changed — 2026-02-01
-
 - Replaced Pagefind with FlexSearch and improved the shared search architecture.
 - Rewrote the README to better reflect the more personal direction of the site.
 
 ## 2026-01-31 — Search empty-state polish
 
-### Added — 2026-01-31
+### Changed — 2026-01-31
 
 - A branded empty state for zero-result searches.
 
 ## 2026-01-28 — CI hardening and feed reliability
 
-### Added — 2026-01-28
-
-- Updated social profile links to better reflect the current public presence of the site owner.
-
 ### Changed — 2026-01-28
 
+- Updated social profile links to better reflect the current public presence of the site owner.
 - Tightened CI with stronger type checking and refreshed dependency automation.
-
-### Fixed — 2026-01-28
-
 - Added more robust RSS generation error handling.
 
 ## 2026-01-26 — Publishing and documentation refinements
 
-### Added — 2026-01-26
+### Changed — 2026-01-26
 
 - Comprehensive README documentation for running, understanding, and contributing to the Astro site.
 - A simplified two-option theme toggle with smoother theme transitions.
-
-### Changed — 2026-01-26
-
 - Extracted shared tag utilities and search modal logic to reduce duplication.
 - Cleaned up semantic wrappers and centralized transition-duration styling.
-
-### Fixed — 2026-01-26
-
 - Disabled Jekyll processing on GitHub Pages during the Astro deployment phase.
 - Normalized tag casing to avoid duplicates in search and tag pages.
 - Corrected the sitemap URL to match the canonical site URL.
@@ -242,80 +182,53 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## 2026-01-24 — Search and tag discovery improvements
 
-### Added — 2026-01-24
+### Changed — 2026-01-24
 
 - Tag pages that combine both blog posts and projects.
 - Search results that surface tags alongside titles and descriptions.
 - A broader set of search modal improvements for discovery and usability.
-
-### Changed — 2026-01-24
-
 - Refactored shared content patterns and smoothed out SPA-like page motion.
 - Improved navigation consistency across tag pages and related flows.
-
-### Fixed — 2026-01-24
-
 - Closed the search modal after selecting a result.
 - Fixed missing color variables and transition settings in light and dark modes.
 - Corrected a structured-data reference in the JsonLd component.
 
 ## 2026-01-23 — UX and codebase cleanup
 
-### Added — 2026-01-23
+### Changed — 2026-01-23
 
 - DevContainer support for more reproducible development setups.
 - Additional home, footer, and layout refinements to improve the reading experience.
-
-### Changed — 2026-01-23
-
 - Extracted components and improved accessibility, SEO, and general code quality across the site.
-
-### Fixed — 2026-01-23
-
 - Removed the unused LinkCard MDX component.
 - Fixed event-listener leaks in the theme picker and search modal.
 - Closed a batch of small UX and maintainability issues across the codebase.
 
 ## 2026-01-22 — Breadcrumbs, tags, and modal search
 
-### Added — 2026-01-22
+### Changed — 2026-01-22
 
 - Breadcrumb navigation across the site.
 - An all-tags page for discovery.
 - A modal-based search experience with an icon trigger.
-
-### Changed — 2026-01-22
-
 - Improved the search modal UI and made tag pages more flexible in layout and navigation.
-
-### Fixed — 2026-01-22
-
 - Corrected header alignment around the logo and theme toggle.
 - Fixed breadcrumb structure on tag pages.
 
 ## 2026-01-21 — Discovery and editorial redesign
 
-### Added — 2026-01-21
-
-- Related-post recommendations, Pagefind search, Vercel analytics, and richer code-block line-number configuration.
-
 ### Changed — 2026-01-21
 
+- Related-post recommendations, Pagefind search, Vercel analytics, and richer code-block line-number configuration.
 - Redesigned the home and about pages toward a cleaner, more personal editorial layout.
 - Removed images from cards and detail pages for a more minimal presentation.
 
 ## 2026-01-17 — Automation and reading experience
 
-### Added — 2026-01-17
-
-- CI automation, Dependabot updates, pre-commit hooks, dark-mode refinements, a reading-progress indicator, and additional static assets.
-
 ### Changed — 2026-01-17
 
+- CI automation, Dependabot updates, pre-commit hooks, dark-mode refinements, a reading-progress indicator, and additional static assets.
 - Simplified agent instructions and removed obsolete image-generation tooling.
-
-### Fixed — 2026-01-17
-
 - Added the missing RSS dependency required by the Astro site.
 
 ## 2026-01-16 — Astro rewrite milestone
@@ -326,80 +239,53 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## 2026-01-15 — MDX and writing experience
 
-### Added — 2026-01-15
+### Changed — 2026-01-15
 
 - Reading-time calculation for posts.
 - MDX support with Expressive Code and improved typography.
 - Callout, image, video, and richer MDX content components.
 - A table of contents with both header and sidebar treatments.
-
-### Changed — 2026-01-15
-
 - Refreshed agent documentation and removed obsolete planning files that no longer matched the site workflow.
 - Removed heading anchor links to simplify the reading experience.
-
-### Fixed — 2026-01-15
-
 - Resolved MDX build, lint, and formatting issues.
 - Improved LinkCard and typography styling for readability.
 
 ## 2026-01-12 — SEO and publishing foundations
 
-### Added — 2026-01-12
-
-- RSS feed generation, sitemap generation, robots.txt, a custom 404 page, a footer, structured SEO, and view transitions.
-
 ### Changed — 2026-01-12
 
+- RSS feed generation, sitemap generation, robots.txt, a custom 404 page, a footer, structured SEO, and view transitions.
 - Simplified blog and project cards into a more text-first layout.
 - Improved navigation prefetching and other performance-oriented behavior.
-
-### Fixed — 2026-01-12
-
 - Resolved early linting and formatting issues.
 - Tightened type annotations for article authors and tags.
 
 ## 2026-01-10 — Blog, about page, and local tooling
 
-### Added — 2026-01-10
+### Changed — 2026-01-10
 
 - Blog cards, blog and tag pagination, paginated project routes, recent-posts and recent-projects sections, a skills module, a timeline module, and a richer About page.
 - ESLint and Prettier configuration, updated package scripts, and better VS Code recommendations for local development.
 - Dedicated agent guidance for working on the Astro codebase.
-
-### Changed — 2026-01-10
-
 - Improved project-card responsiveness and tidied utility styling.
-
-### Fixed — 2026-01-10
-
 - Resolved early build, linting, and formatting issues in the Astro codebase.
 
 ## 2026-01-09 — Content collections and dynamic project pages
 
-### Added — 2026-01-09
+### Changed — 2026-01-09
 
 - Zod-backed content collections for blog posts and projects.
 - Dynamic project listings, project-detail pages, and shared data utilities for content management.
 - Initial seed content to exercise the new Astro content model.
-
-### Changed — 2026-01-09
-
 - Replaced placeholder homepage content with dynamic recent-project flows.
 - Simplified project metadata by removing the old featured and ordering fields.
 
 ## 2026-01-04 — Astro reboot
 
-### Added — 2026-01-04
+### Changed — 2026-01-04
 
 - A new Astro + Bun foundation for the site.
 - Tailwind CSS, shared site configuration, navigation links, social links, header and hero primitives, theming support, and early homepage project scaffolding.
 - Path aliases and styling improvements to support the new Astro architecture.
-
-### Changed — 2026-01-04
-
 - Reoriented the repository around the Astro implementation and updated the README to match the new stack.
-
-### Removed — 2026-01-04
-
 - The previous Next.js codebase, workflows, configs, and app-router implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,31 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## Unreleased
 
-### Removed
+### Changed — 2026-05-21
 
-- FlexSearch-powered search modal, search index API endpoint, icon trigger, and all related infrastructure to simplify the codebase until more content is available.
+- Remove unused options (`limit`, `includeDrafts`) from `getAllBlogPosts`
+  and unused options (`tags`, `limit`) from `getAllProjects`.
+- Remove unused `sortBy` parameter from `sortProjects`; always sort by date.
+- Remove redundant TOC heading filter in `TOCList` — callers already
+  pre-filter headings.
+- Deduplicate social URLs by deriving JSON-LD `sameAs` from `socialLinks`
+  instead of separate top-level fields.
+- Extract shared prompt, template, and file-writing helpers into
+  `scaffold-utils.js`, reducing duplication between content scaffolding
+  CLI scripts.
+- Unexport `ContentTag`, `ScrollRevealOptions`, and `TocController` types
+  that had no external consumers.
+
+### Fixed — 2026-05-21
+
+- Resolve iPhone header transparency issue near the dynamic island where
+  the status bar area showed through the navigation bar.
+
+### Removed — 2026-05-21
+
+- FlexSearch-powered search modal, search index API endpoint, icon trigger,
+  and all related infrastructure to simplify the codebase until more
+  content is available.
 
 ## 2026-05-21 — Swiss redesign and MDX/content architecture overhaul
 


### PR DESCRIPTION
## Summary
Standardizes the changelog format around dated category entries (`### Changed — YYYY-MM-DD`) throughout the entire history, and rewrites AGENTS.md as a lean pointer file with explicit changelog instructions.

## Changes
- **CHANGELOG.md**: Add dates to every historical category header to match the new uniform format; update `## Unreleased` entries with today's date
- **AGENTS.md**: Rewrite as a minimal pointer file referencing sources of truth (`src/content.config.ts`, `src/consts.ts`, `CHANGELOG.md`, etc.) instead of duplicating their contents; add explicit instructions on changelog format with date-stamped category subsections

## Testing
- [x] `bun run verify` passed (type-check, lint, format, test, build)