### PR TITLE
chore: remove stale optimizeDeps entries for clsx and tailwind-merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
-### Changed — 2026-05-22
+### Removed — 2026-05-22
 
+- Remove stale `clsx` and `tailwind-merge` entries from
+  `vite.optimizeDeps.include` in Astro config — these packages were
+  removed in a previous cleanup.
 - Remove standalone `DESIGN.md` design spec — design tokens are now
   maintained in the source code and Tailwind config.
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -84,10 +84,6 @@ export default defineConfig({
         clientFiles: ["./src/components/**/*.astro", "./src/layouts/**/*.astro"],
       },
     },
-    optimizeDeps: {
-      // Pre-bundle these dependencies
-      include: ["clsx", "tailwind-merge"],
-    },
     build: {
       rollupOptions: {
         onwarn(warning, warn) {


### PR DESCRIPTION
## Summary

Removes stale `vite.optimizeDeps.include` entries from `astro.config.ts` that referenced `clsx` and `tailwind-merge` — both packages were removed in PR #237.

## Changes
- Removed the `optimizeDeps.include` block from Astro config
- Updated CHANGELOG under Unreleased

## Testing
**Automated**
- [x] `bun run verify` passed (type-check, lint, format, 1 test, build)