### PR TITLE
docs: clarify changelog category guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,16 @@ Browse `src/components/` and `src/lib/` for existing patterns before introducing
 
 - Use `@/` path alias for all imports from `src/`.
 - Update `CHANGELOG.md` for every notable change. Add entries under
-  `## Unreleased`, grouped by category (`### Added`, `### Changed`,
-  `### Fixed`, `### Removed`). Each category header must include today's
-  date: `### Changed — YYYY-MM-DD`. If a subsection with today's date
-  already exists, append to it instead of creating a duplicate.
+  `## Unreleased`, grouped by the category that best describes the
+  change:
+  - `### Added` for new features
+  - `### Changed` for modifications to existing functionality
+  - `### Removed` for deleted files, dependencies, or features
+  - `### Fixed` for bug fixes
+    Each category header must include today's date
+    (e.g., `### Removed — YYYY-MM-DD`). If a subsection with today's
+    date and the same category already exists, append to it instead of
+    creating a duplicate.
 - Run `bun run verify` before every push.
 - Commit and PR titles must use Conventional Commits (`feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`).
 - Branch from the latest `main`; never commit directly to `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
+### Changed — 2026-05-22
+
+- Clarify changelog category guidance in AGENTS.md — spell out which
+  category (`Added`, `Changed`, `Removed`, `Fixed`) fits which scenario
+  instead of a single `Changed` example.
+
 ### Removed — 2026-05-22
 
 - Remove stale `clsx` and `tailwind-merge` entries from


### PR DESCRIPTION
## Summary

Clarifies the changelog category rules in AGENTS.md to prevent future misclassification. The previous wording used `### Changed — YYYY-MM-DD` as the sole example, which led to entries being incorrectly filed under Changed instead of Removed.

## Changes
- Expanded the changelog rule to spell out which category (`Added`, `Changed`, `Removed`, `Fixed`) fits which scenario
- Updated CHANGELOG under Unreleased

## Testing
**Automated**
- [x] `bun run verify` passed (type-check, lint, format, 1 test, build)