### PR TITLE
refactor: remove redundant sortProjects calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this site are documented in this file.
 - Clarify changelog category guidance in AGENTS.md — spell out which
   category (`Added`, `Changed`, `Removed`, `Fixed`) fits which scenario
   instead of a single `Changed` example.
+- Remove redundant `sortProjects()` call in projects pagination page
+  and redundant `sortProjects()` wrapper in tags page — `getAllProjects()`
+  already returns projects sorted by date descending.
 
 ### Removed — 2026-05-22
 

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -9,13 +9,12 @@ import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
 import { groupByYear } from "@/lib/group-by-year";
 import { buildPaginationUrls, generatePaginatedPaths } from "@/lib/paginated-routes";
-import { getAllProjects, sortProjects } from "@/lib/projects";
+import { getAllProjects } from "@/lib/projects";
 import type { CollectionEntry } from "astro:content";
 
 export async function getStaticPaths() {
   const allProjects = await getAllProjects();
-  const sortedProjects = sortProjects(allProjects);
-  return generatePaginatedPaths(sortedProjects, SITE.projectsPerPage);
+  return generatePaginatedPaths(allProjects, SITE.projectsPerPage);
 }
 
 interface Props {

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -10,7 +10,7 @@ import Layout from "@/layouts/Layout.astro";
 import { getAllBlogPosts } from "@/lib/blog";
 import { getAllContentTags } from "@/lib/content-tags";
 import { groupByYear } from "@/lib/group-by-year";
-import { getAllProjects, sortProjects } from "@/lib/projects";
+import { getAllProjects } from "@/lib/projects";
 import { getTagHref, slugifyTag } from "@/lib/tags";
 import type { CollectionEntry } from "astro:content";
 
@@ -25,8 +25,8 @@ export async function getStaticPaths() {
     const filteredPosts = allPosts.filter((post) =>
       post.data.tags.some((tag) => slugifyTag(tag) === slug)
     );
-    const filteredProjects = sortProjects(
-      allProjects.filter((project) => project.data.tags.some((tag) => slugifyTag(tag) === slug))
+    const filteredProjects = allProjects.filter((project) =>
+      project.data.tags.some((tag) => slugifyTag(tag) === slug)
     );
 
     return {


### PR DESCRIPTION
## Summary
Removed unnecessary `sortProjects()` calls in the projects pagination and tags pages. `getAllProjects()` already returns projects sorted by date descending, so the extra sort was a no-op.

## Changes
- Removed `sortProjects` import and call from `src/pages/projects/[...page].astro`
- Removed `sortProjects` wrapper from filtered projects in `src/pages/tags/[tag].astro`

## Testing
**Automated**
- [x] `bun run verify` passed (type-check, lint, format, 1 test, build)