### PR TITLE
fix: prevent theme flash and harden active-link matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ All notable changes to this site are documented in this file.
   and redundant `sortProjects()` wrapper in tags page — `getAllProjects()`
   already returns projects sorted by date descending.
 
+### Fixed — 2026-05-22
+
+- Prevent flash of unstyled content by setting `data-theme="dark"` directly
+  on the `<html>` element instead of via a late inline script at the end of
+  `<body>` — the attribute is now present at first paint.
+- Harden active-link matching in the header nav: replace brittle
+  `startsWith()` with exact match + guarded prefix matching, handle
+  `BASE_URL`, and add `aria-current="page"` for accessibility.
+
 ### Removed — 2026-05-22
 
 - Remove stale `clsx` and `tailwind-merge` entries from

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,6 +5,12 @@ import Container from "@/components/ui/Container.astro";
 import { Icon } from "astro-icon/components";
 
 const currentPath = Astro.url.pathname;
+
+/** Whether a nav link matches the current page (exact match or child route). */
+const isCurrentPage = (href: string) => {
+  const pathname = currentPath.replace(import.meta.env.BASE_URL, "/");
+  return href === "/" ? pathname === "/" : pathname === href || pathname.startsWith(href + "/");
+};
 ---
 
 <Container class="flex items-center justify-between py-4 md:py-5">
@@ -22,11 +28,12 @@ const currentPath = Astro.url.pathname;
     <nav class="flex items-center gap-5">
       {
         NAV_LINKS.map((link) => {
-          const isActive = currentPath.startsWith(link.href);
+          const active = isCurrentPage(link.href);
           return (
             <Link
               href={link.href}
-              class:list={["nav-link", isActive && "active"]}
+              class:list={["nav-link", active && "active"]}
+              aria-current={active ? "page" : undefined}
               prefetch="viewport"
             >
               {link.label}
@@ -82,15 +89,16 @@ const currentPath = Astro.url.pathname;
     <ul class="flex flex-col mt-2">
       {
         NAV_LINKS.map((link) => {
-          const isActive = currentPath.startsWith(link.href);
+          const active = isCurrentPage(link.href);
           return (
             <li>
               <a
                 href={link.href}
                 class:list={[
                   "flex items-center justify-between px-6 py-4 nav-link border-b border-[var(--color-border)]",
-                  isActive && "active",
+                  active && "active",
                 ]}
+                aria-current={active ? "page" : undefined}
               >
                 {link.label}
                 <Icon name="fa6-solid:arrow-right" class="w-3 h-3 opacity-30" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,7 +30,7 @@ const {
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
@@ -81,11 +81,6 @@ const {
       <Footer />
     </div>
     <ScrollReveal />
-
-    <script is:inline>
-      // Lock to dark theme always
-      document.documentElement.setAttribute("data-theme", "dark");
-    </script>
 
     <script>
       // First-load entrance animation: play once per session, skip on back-navigation


### PR DESCRIPTION
## Summary
Two low-severity fixes: eliminate a flash of unstyled content by baking `data-theme=\"dark\"` directly into the `<html>` tag, and replace brittle `startsWith()` active-link matching with a robust pattern following official Astro examples.

## Changes
- **Theme flash fix** — Removed the late `<script is:inline>` at the end of `<body>` that set `data-theme`; instead hardcoded `data-theme=\"dark\"` directly on the `<html>` element. The attribute is now present at first paint.
- **Active-link hardening** — Replaced `currentPath.startsWith(link.href)` with `isCurrentPage()` that uses exact match + guarded prefix (`href + \"/\"`), handles `import.meta.env.BASE_URL`, and adds `aria-current=\"page\"` for accessibility. Applied in both desktop nav (Link component) and mobile nav drawer.

## Testing
**Automated**
- [x] `bun run verify` passed (type-check, lint, format, 1 test, build)

## Notes
Both patterns verified against Astro's official docs and examples: the portfolio example puts theme scripts in `<head>` with `is:inline` to make them blocking, and both the portfolio and blog examples avoid bare `startsWith()` in favor of exact + guarded prefix matching.