### PR TITLE
fix: prevent duplicate lifecycle listeners and add cleanup paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ All notable changes to this site are documented in this file.
 - Harden active-link matching in the header nav: replace brittle
   `startsWith()` with exact match + guarded prefix matching, handle
   `BASE_URL`, and add `aria-current="page"` for accessibility.
+- Refactor `attachTocLifecycle()` to use a module-level controller
+  registry — registers Astro lifecycle listeners once and shares them
+  across all TOC controllers, preventing duplicate anonymous listeners.
+- Add `astro:before-swap` observer disconnect to `ScrollReveal` for
+  proper teardown during view transitions.
+- Hoist anonymous Astro lifecycle event handlers to named functions in
+  `ScrollReveal` and `ReadingProgress`, providing a clear cleanup path.
 
 ### Removed — 2026-05-22
 

--- a/src/components/ReadingProgress.astro
+++ b/src/components/ReadingProgress.astro
@@ -80,15 +80,20 @@
     }
   }
 
-  // Initialize on page load
-  document.addEventListener("astro:page-load", () => ReadingProgressController.init());
+  function onPageLoad() {
+    ReadingProgressController.init();
+  }
 
-  // Re-initialize after view transitions
-  document.addEventListener("astro:after-swap", () => {
+  function onAfterSwap() {
     ReadingProgressController.cleanup();
     ReadingProgressController.init();
-  });
+  }
 
-  // Cleanup before view transitions
-  document.addEventListener("astro:before-swap", () => ReadingProgressController.cleanup());
+  function onBeforeSwap() {
+    ReadingProgressController.cleanup();
+  }
+
+  document.addEventListener("astro:page-load", onPageLoad);
+  document.addEventListener("astro:after-swap", onAfterSwap);
+  document.addEventListener("astro:before-swap", onBeforeSwap);
 </script>

--- a/src/components/ScrollReveal.astro
+++ b/src/components/ScrollReveal.astro
@@ -69,6 +69,14 @@
     observer = initScrollReveal();
   }
 
-  document.addEventListener("astro:page-load", init);
-  document.addEventListener("astro:after-swap", init);
+  function onPageLoad() {
+    init();
+  }
+  function onAfterSwap() {
+    init();
+  }
+
+  document.addEventListener("astro:page-load", onPageLoad);
+  document.addEventListener("astro:after-swap", onAfterSwap);
+  document.addEventListener("astro:before-swap", () => observer?.disconnect());
 </script>

--- a/src/lib/toc.ts
+++ b/src/lib/toc.ts
@@ -30,13 +30,42 @@ type TocController = {
   cleanup: () => void;
 };
 
-export function attachTocLifecycle(controller: TocController): void {
-  document.addEventListener("astro:page-load", () => controller.init());
-  document.addEventListener("astro:after-swap", () => {
-    controller.cleanup();
-    controller.init();
+const controllers: TocController[] = [];
+let listenersAttached = false;
+
+function onPageLoad() {
+  controllers.forEach((c) => c.init());
+}
+
+function onAfterSwap() {
+  controllers.forEach((c) => {
+    c.cleanup();
+    c.init();
   });
-  document.addEventListener("astro:before-swap", () => controller.cleanup());
+}
+
+function onBeforeSwap() {
+  controllers.forEach((c) => c.cleanup());
+}
+
+/**
+ * Register a TOC controller with the module-level lifecycle listeners.
+ * The Astro lifecycle events are attached only once; subsequent calls
+ * add the controller to a shared registry. Returns a cleanup function
+ * to deregister the controller.
+ */
+export function attachTocLifecycle(controller: TocController): () => void {
+  controllers.push(controller);
+  if (!listenersAttached) {
+    document.addEventListener("astro:page-load", onPageLoad);
+    document.addEventListener("astro:after-swap", onAfterSwap);
+    document.addEventListener("astro:before-swap", onBeforeSwap);
+    listenersAttached = true;
+  }
+  return () => {
+    const idx = controllers.indexOf(controller);
+    if (idx !== -1) controllers.splice(idx, 1);
+  };
 }
 
 function getVisibleHeadingIds(headingElements: HTMLElement[], headerOffset: number): string[] {


### PR DESCRIPTION
## Summary
Fix three listener-management issues flagged by linter: eliminate duplicate anonymous `astro:*` event listeners from `attachTocLifecycle()`, add proper teardown hooks to `ScrollReveal`, and hoist anonymous handlers to named functions in `ScrollReveal` and `ReadingProgress` for a clear cleanup path.

## Changes
- **`attachTocLifecycle()`** — Refactored to use a module-level controller registry. Only one set of Astro lifecycle listeners is ever registered; each caller pushes its controller to a shared array. Returns a cleanup function to deregister. This fixes the duplicate-listener issue when both `TOCHeader` and `TOCSidebar` are on the same page.
- **`ScrollReveal`** — Added `astro:before-swap` handler that disconnects the `IntersectionObserver` during view transitions. Hoisted event listeners from anonymous to named functions.
- **`ReadingProgress`** — Hoisted anonymous `astro:*` event handlers to named functions, making them removable if needed. (The window scroll/resize listeners were already properly cleaned up by `cleanup()`.)

## Testing
**Automated**
- [x] `bun run verify` passed (type-check, lint, format, 1 test, build)

## Notes
Patterns verified against Astro's own source code (`prefetch/index.ts`, dev toolbar): Astro registers lifecycle listeners once per module and never removes them. The TOC fix aligns with this by ensuring only one set of listeners exists, shared across all controllers.