### PR TITLE
fix: comply with Web Interface Guidelines (a11y, UX, formatting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
+### Added — 2026-05-24
+
+- Skip-to-content link for keyboard accessibility.
+- `touch-action: manipulation` on interactive elements to prevent
+  double-tap zoom delay on mobile.
+- `overscroll-behavior: contain` on mobile navigation drawer to prevent
+  background scroll bleed.
+
+### Fixed — 2026-05-24
+
+- Apply `aria-hidden="true"` to decorative icons in `ContentCard`,
+  `FooterLink`, `TOCHeader`, and `Callout` components.
+- Update URL hash via `history.replaceState` on TOC link clicks to
+  preserve deep-linking while maintaining smooth-scroll behavior.
+- Replace hardcoded `formatDate` with `Intl.DateTimeFormat` and
+  hardcoded reading-time string with `Intl.NumberFormat`.
+- Add `fetchpriority="high"` and `aspect-video` to hero images for CLS
+  prevention.
+- Add `<meta name="theme-color">` matching the dark background.
+- Replace hyphen with em-dash and straight quotes with curly quotes in
+  site description and tag-page metadata.
+- Remove unused `getOrdinalSuffix` utility.
+
 ### Changed — 2026-05-22
 
 - Clarify changelog category guidance in AGENTS.md — spell out which

--- a/src/components/ContentCard.astro
+++ b/src/components/ContentCard.astro
@@ -27,6 +27,7 @@ const { title, description, tags, href, meta, class: className } = Astro.props;
           name="fa6-solid:arrow-right"
           class="w-4 h-4 shrink-0 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity"
           style="color: var(--color-card-hover-text);"
+          aria-hidden="true"
         />
       </div>
       {meta && <p class="eyebrow">{meta}</p>}

--- a/src/components/ContentDetailPage.astro
+++ b/src/components/ContentDetailPage.astro
@@ -100,7 +100,13 @@ const {
   {
     heroImage && (
       <div class="col-start-2 px-6 md:px-8 page-enter page-enter-delay-2">
-        <img src={heroImage} alt={title} class="w-full object-cover" />
+        <img
+          src={heroImage}
+          alt={title}
+          class="w-full object-cover aspect-video"
+          fetchpriority="high"
+          loading="eager"
+        />
       </div>
     )
   }

--- a/src/components/ContentDetailPage.astro
+++ b/src/components/ContentDetailPage.astro
@@ -103,6 +103,8 @@ const {
         <img
           src={heroImage}
           alt={title}
+          width="1200"
+          height="675"
           class="w-full object-cover aspect-video"
           fetchpriority="high"
           loading="eager"

--- a/src/components/FooterLink.astro
+++ b/src/components/FooterLink.astro
@@ -14,7 +14,8 @@ const { href, external = false, class: className } = Astro.props;
   {...external ? { target: "_blank", rel: "noopener noreferrer" } : {}}
 >
   <span class="footer-link-text"><slot /></span>
-  <span class:list={external ? "footer-link-arrow-external" : "footer-link-arrow-internal"}
-    >{external ? "↗" : "→"}</span
+  <span
+    class:list={external ? "footer-link-arrow-external" : "footer-link-arrow-internal"}
+    aria-hidden="true">{external ? "↗" : "→"}</span
   >
 </a>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,6 +19,7 @@ const isCurrentPage = (href: string) => {
     class="text-xl font-bold tracking-tight"
     style="color: var(--color-accent);"
     data-astro-prefetch="tap"
+    translate="no"
   >
     AS
   </a>
@@ -53,7 +54,7 @@ const isCurrentPage = (href: string) => {
       aria-controls="mobile-nav-drawer"
       class="icon-button p-2"
     >
-      <Icon name="fa6-solid:bars" class="w-4 h-4" />
+      <Icon name="fa6-solid:bars" class="w-4 h-4" aria-hidden="true" />
     </button>
   </div>
 </Container>
@@ -81,7 +82,7 @@ const isCurrentPage = (href: string) => {
     >
       <span class="eyebrow">Menu</span>
       <button id="mobile-nav-close" aria-label="Close navigation menu" class="icon-button p-2">
-        <Icon name="fa6-solid:xmark" class="w-4 h-4" />
+        <Icon name="fa6-solid:xmark" class="w-4 h-4" aria-hidden="true" />
       </button>
     </div>
 
@@ -101,7 +102,7 @@ const isCurrentPage = (href: string) => {
                 aria-current={active ? "page" : undefined}
               >
                 {link.label}
-                <Icon name="fa6-solid:arrow-right" class="w-3 h-3 opacity-30" />
+                <Icon name="fa6-solid:arrow-right" class="w-3 h-3 opacity-30" aria-hidden="true" />
               </a>
             </li>
           );

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -72,7 +72,7 @@ const isCurrentPage = (href: string) => {
     aria-modal="true"
     aria-label="Navigation menu"
     class="absolute right-0 top-0 bottom-0 w-64 flex flex-col pointer-events-auto"
-    style="background: var(--color-base); border-left: 1px solid var(--color-border); transform: translateX(100%); transition: transform 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94);"
+    style="background: var(--color-base); border-left: 1px solid var(--color-border); transform: translateX(100%); transition: transform 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); overscroll-behavior: contain;"
   >
     <!-- Drawer header -->
     <div

--- a/src/components/TOCHeader.astro
+++ b/src/components/TOCHeader.astro
@@ -47,7 +47,7 @@ const { headings, class: className } = Astro.props;
             </div>
             <span
               id="mobile-toc-current-section"
-              class="grow truncate text-sm"
+              class="grow min-w-0 truncate text-sm"
               style="color: var(--color-muted);"
             >
               Overview

--- a/src/components/TOCHeader.astro
+++ b/src/components/TOCHeader.astro
@@ -21,7 +21,7 @@ const { headings, class: className } = Astro.props;
           <Container class="flex items-center py-3">
             {/* Progress circle */}
             <div class="relative mr-2 size-4">
-              <svg class="h-4 w-4" viewBox="0 0 24 24">
+              <svg class="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
                 <circle
                   class="opacity-20"
                   cx="12"
@@ -56,6 +56,7 @@ const { headings, class: className } = Astro.props;
               <Icon
                 name="fa6-solid:chevron-down"
                 class="w-4 h-4 transition-transform duration-200 group-open:rotate-180"
+                aria-hidden="true"
               />
             </span>
           </Container>

--- a/src/components/mdx/Callout.astro
+++ b/src/components/mdx/Callout.astro
@@ -41,12 +41,14 @@ const displayTitle = title || variant.charAt(0).toUpperCase() + variant.slice(1)
           name={config.icon}
           class="w-4 h-4 mr-2 shrink-0"
           style="color: var(--color-accent);"
+          aria-hidden="true"
         />
         <span class="font-medium">{displayTitle}</span>
         <Icon
           name="fa6-solid:chevron-down"
           class="chevron w-4 h-4 ml-auto shrink-0 transition-transform duration-200"
           style="color: var(--color-muted);"
+          aria-hidden="true"
         />
       </summary>
       <div style="color: var(--color-muted-foreground);">
@@ -67,6 +69,7 @@ const displayTitle = title || variant.charAt(0).toUpperCase() + variant.slice(1)
           name={config.icon}
           class="w-4 h-4 mr-2 shrink-0"
           style="color: var(--color-accent);"
+          aria-hidden="true"
         />
         <span class="font-medium">{displayTitle}</span>
       </div>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,7 +2,7 @@
 export const SITE = {
   // Meta
   title: "Abijith S",
-  description: "Personal portfolio and blog of Abijith S - developer, builder, writer.",
+  description: "Personal portfolio and blog of Abijith S — developer, builder, writer.",
   url: "https://abijith.sh",
   domain: "abijith.sh",
   locale: "en-US",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -35,6 +35,7 @@ const {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="generator" content={Astro.generator} />
+    <meta name="theme-color" content="#111111" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -67,6 +68,12 @@ const {
     <slot name="head" />
   </head>
   <body class="flex h-fit min-h-screen flex-col">
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-[var(--color-accent)] focus:text-[var(--color-base)] focus:font-medium"
+    >
+      Skip to content
+    </a>
     <header
       class="bg-[var(--color-base)] sticky top-0 z-50 border-b border-[var(--color-border)]"
       style="view-transition-name: site-header; padding-top: env(safe-area-inset-top, 0px);"
@@ -74,7 +81,11 @@ const {
       <Header />
       <slot name="table-of-contents" />
     </header>
-    <main class="w-full mx-auto flex grow flex-col" style="view-transition-name: page-main;">
+    <main
+      id="main-content"
+      class="w-full mx-auto flex grow flex-col"
+      style="view-transition-name: page-main;"
+    >
       <slot />
     </main>
     <div style="view-transition-name: site-footer;">

--- a/src/lib/toc.ts
+++ b/src/lib/toc.ts
@@ -148,7 +148,11 @@ export function createDesktopTocController(config: DesktopTocConfig): TocControl
         if (!headingId) return;
         event.preventDefault();
         const heading = document.getElementById(headingId);
-        heading?.scrollIntoView({ behavior: "smooth", block: "start" });
+        if (!heading) return;
+        const url = new URL(window.location.href);
+        url.hash = headingId;
+        history.replaceState(null, "", url.toString());
+        heading.scrollIntoView({ behavior: "smooth", block: "start" });
       };
       linkListeners.set(link, handler);
       link.addEventListener("click", handler);
@@ -287,7 +291,11 @@ export function createMobileTocController(config: MobileTocConfig): TocControlle
           if (headingId) {
             event.preventDefault();
             const heading = document.getElementById(headingId);
-            heading?.scrollIntoView({ behavior: "smooth", block: "start" });
+            if (!heading) return;
+            const url = new URL(window.location.href);
+            url.hash = headingId;
+            history.replaceState(null, "", url.toString());
+            heading.scrollIntoView({ behavior: "smooth", block: "start" });
           }
         }
         if (state.detailsElement) state.detailsElement.open = false;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,27 +2,12 @@ export function cn(...inputs: (string | undefined | null | false)[]) {
   return inputs.filter(Boolean).join(" ");
 }
 
-function getOrdinalSuffix(day: number): string {
-  if (day > 3 && day < 21) return "th";
-  switch (day % 10) {
-    case 1:
-      return "st";
-    case 2:
-      return "nd";
-    case 3:
-      return "rd";
-    default:
-      return "th";
-  }
-}
-
 export function formatDate(date: Date): string {
-  const month = date.toLocaleDateString("en-US", { month: "long" });
-  const day = date.getDate();
-  const year = date.getFullYear();
-  const suffix = getOrdinalSuffix(day);
-
-  return `${month} ${day}${suffix}, ${year}`;
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(date);
 }
 
 export function calculateReadingTime(content: string, wordsPerMinute = 200): number {
@@ -32,5 +17,5 @@ export function calculateReadingTime(content: string, wordsPerMinute = 200): num
 }
 
 export function formatReadingTime(minutes: number): string {
-  return `${minutes} min read`;
+  return new Intl.NumberFormat("en-US").format(minutes) + " min read";
 }

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -85,7 +85,7 @@ const contentByYear = groupByYear(allContent, (item) => item.date);
 
 <Layout
   title={`Tag: ${tagLabel} - ${SITE.title}`}
-  description={`Content tagged with "${tagLabel}"`}
+  description={`Content tagged with “${tagLabel}”`}
   canonicalURL={canonicalURL}
   jsonLd={{ type: "website" }}
 >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -76,6 +76,16 @@
     position: relative;
   }
 
+  button,
+  a,
+  [role="button"],
+  input,
+  select,
+  textarea,
+  summary {
+    touch-action: manipulation;
+  }
+
   body::before {
     content: "";
     position: fixed;


### PR DESCRIPTION
## Summary

Applies fixes identified by the Vercel Web Interface Guidelines review across accessibility, touch/mobile UX, deep-linking, CLS prevention, and localization. All changes are non-breaking and improve compliance without altering the visual design.

## Changes

- Add `aria-hidden="true"` to all decorative icons across the codebase (ContentCard, FooterLink, TOCHeader, Callout, Header)
- Add skip-to-content link with accent focus ring for keyboard users
- Add `<meta name="theme-color">` matching the dark background
- Add `translate="no"` on the "AS" brand monogram
- Add `touch-action: manipulation` globally on interactive elements to prevent mobile double-tap zoom delay
- Add `overscroll-behavior: contain` on mobile nav drawer to prevent background scroll bleed
- Update URL hash via `history.replaceState` on TOC link clicks to preserve deep-linking during smooth scroll
- Replace hardcoded date formatting with `Intl.DateTimeFormat` and reading-time string with `Intl.NumberFormat`
- Add `fetchpriority="high"`, `width`/`height`, and `aspect-video` to hero images for CLS prevention
- Add `min-w-0` to mobile TOC section label for correct text truncation
- Replace hyphen with em-dash in site description, straight quotes with curly quotes in tag metadata

## Testing

**Automated**
- [x] `bun run verify` passed (type-check, lint, format, tests, build)

**Manual**
- [x] **Skip-to-content link** — tab to page on any route; verify visible focus ring appears top-left
- [x] **Date formatting** — check blog post and project detail pages; dates now use `Intl.DateTimeFormat` format (e.g. "May 24, 2026" without ordinal suffix)
- [x] **TOC deep-linking** — click a heading in the desktop sidebar or mobile TOC; verify the URL hash updates in the address bar
- [x] **Hero image** — blog post detail page: verify hero image loads with correct aspect ratio and no layout shift
- [x] **Site description** — view page source or social previews; verify em-dash replaces hyphen in meta description
- [x] **Mobile nav drawer** — open nav on mobile; verify drawer scroll doesn't bleed through to page background

## Notes

- The date format change from ordinal ("May 24th, 2026") to `Intl.DateTimeFormat` ("May 24, 2026") is intentional per the guidelines' locale/i18n rules. This is a visible change on all content pages.
- TOC click behavior now updates the browser URL hash — this enables deep-linking but the smooth-scroll UX is preserved.