### PR TITLE
chore: update now page reading and watching entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
+### Changed — 2026-08-31
+
+- Update the now page current watching entry to The Apothecary Diaries and
+  reading entry to Essentialism by Greg McKeown.
+
 ### Changed — 2026-08-22
 
 - Update the now page current watching entry to Journal with Witch.

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -48,20 +48,20 @@ const routeMetadata = getStaticRouteMetadata("/now/");
 
       <p style="color:var(--color-muted-foreground)">
         Watching — <a
-          href="https://anilist.co/anime/177385/Journal-with-Witch/"
+          href="https://anilist.co/anime/161645/Kusuriya-no-Hitorigoto/"
           class="text-link"
           target="_blank"
-          rel="noopener noreferrer">Journal with Witch</a
+          rel="noopener noreferrer">The Apothecary Diaries</a
         >.
       </p>
 
       <p style="color:var(--color-muted-foreground)">
         Reading — <a
-          href="https://www.goodreads.com/book/show/55710822-better-than-the-movies"
+          href="https://www.goodreads.com/book/show/19776547-essentialism"
           class="text-link"
           target="_blank"
-          rel="noopener noreferrer">Better Than the Movies</a
-        > by Lynn Painter.
+          rel="noopener noreferrer">Essentialism</a
+        > by Greg McKeown.
       </p>
     </Container>
   </PageShell>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the now page with current media:

- **Watching:** [The Apothecary Diaries](https://anilist.co/anime/161645/Kusuriya-no-Hitorigoto/) (AniList)
- **Reading:** [Essentialism](https://www.goodreads.com/book/show/19776547-essentialism) by Greg McKeown (Goodreads)

`bun run verify` passes locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05602-4a72-785f-8e31-b2d33daaeb4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05602-4a72-785f-8e31-b2d33daaeb4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

